### PR TITLE
feat(genesis): Add remaining CLI commands

### DIFF
--- a/x/genesis/client/cli/query.go
+++ b/x/genesis/client/cli/query.go
@@ -27,6 +27,9 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 		CmdShowChain(),
 		CmdShowProposal(),
 		CmdPendingProposals(),
+		CmdRejectedProposals(),
+		CmdApprovedProposals(),
+		CmdCurrentGenesis(),
 	)
 
 	return cmd
@@ -182,6 +185,115 @@ func CmdPendingProposals() *cobra.Command {
 		},
 	}
 
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// CmdApprovedProposals returns the command to list approved proposals for a chain genesis
+func CmdApprovedProposals() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "approved-proposals [chain-id]",
+		Short: "list the approved proposals for a chain genesis",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.ReadQueryCommandFlags(clientCtx, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryApprovedProposalsRequest{
+				ChainID: args[0],
+			}
+
+			// Perform the request
+			res, err := queryClient.ApprovedProposals(context.Background(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintOutput(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// CmdRejectedProposals returns the command to list rejected proposals for a chain genesis
+func CmdRejectedProposals() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rejected-proposals [chain-id]",
+		Short: "list the rejected proposals for a chain genesis",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.ReadQueryCommandFlags(clientCtx, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryRejectedProposalsRequest{
+				ChainID: args[0],
+			}
+
+			// Perform the request
+			res, err := queryClient.RejectedProposals(context.Background(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintOutput(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// CmdCurrentGenesis returns the command to show the current genesis for a chain
+func CmdCurrentGenesis() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "current-genesis [chain-id]",
+		Short: "show the current genesis for the chain from the initial genesis and approved proposals",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.ReadQueryCommandFlags(clientCtx, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryCurrentGenesisRequest{
+				ChainID: args[0],
+			}
+
+			// Perform the request
+			res, err := queryClient.CurrentGenesis(context.Background(), params)
+			if err != nil {
+				return err
+			}
+
+			// Check if the genesis must be save in a file
+			genesisFile, _ := cmd.Flags().GetString(FlagSaveGenesis)
+			if genesisFile != "" {
+				ioutil.WriteFile(genesisFile, res.Genesis, 0644)
+			}
+
+			return clientCtx.PrintOutput(res)
+		},
+	}
+
+	cmd.Flags().AddFlagSet(FlagSetSaveGenesis())
 	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd

--- a/x/genesis/client/cli/tx.go
+++ b/x/genesis/client/cli/tx.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io/ioutil"
+	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -29,6 +30,8 @@ func GetTxCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		CmdChainCreate(),
+		CmdApprove(),
+		CmdReject(),
 		CmdProposalAddAccount(),
 		CmdProposalAddValidator(),
 	)
@@ -68,6 +71,80 @@ func CmdChainCreate() *cobra.Command {
 				args[1],
 				args[2],
 				genesis,
+			)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// CmdApprove returns the transaction command to approve a specific proposal
+func CmdApprove() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "proposal-approve [chain-id] [proposal-id]",
+		Short: "Approve a proposal",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.ReadTxCommandFlags(clientCtx, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			// Convert value for proposal ID
+			proposalID, err := strconv.Atoi(args[1])
+			if err != nil {
+				return err
+			}
+
+			// Create and send message
+			msg := types.NewMsgApprove(
+				args[0],
+				int32(proposalID),
+				clientCtx.GetFromAddress(),
+			)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// CmdApprove returns the transaction command to reject a specific proposal
+func CmdReject() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "proposal-reject [chain-id] [proposal-id]",
+		Short: "Reject a proposal",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			clientCtx, err := client.ReadTxCommandFlags(clientCtx, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			// Convert value for proposal ID
+			proposalID, err := strconv.Atoi(args[1])
+			if err != nil {
+				return err
+			}
+
+			// Create and send message
+			msg := types.NewMsgReject(
+				args[0],
+				int32(proposalID),
+				clientCtx.GetFromAddress(),
 			)
 			if err := msg.ValidateBasic(); err != nil {
 				return err


### PR DESCRIPTION
Add CLI commands to approve and reject proposals, list approved and rejected proposals and print the current genesis.

Overview of the commands:
```
Chains:
spnd tx genesis create-chain <chain-id> <source-url> <source-hash> <genesis-path> --from user1 --keyring-backend test --chain-id spn --gas 300000

spnd q genesis list-chains
spnd q genesis show-chain <chain-id> [—save-genesis <genesis-path>]

Proposals:
spnd tx genesis proposal-add-account <chain-id> <tokens> --from user1 --keyring-backend test --chain-id spn
spnd tx genesis proposal-add-validator <chain-id> <peer> <gentx-path> --from user1 --keyring-backend test --chain-id spn --gas 300000

spnd q genesis show-proposal <chain-id> <proposal-id>
spnd q genesis approved-proposals <chain-id>
spnd q genesis pending-proposals <chain-id>
spnd q genesis rejected-proposals <chain-id>

Approvals:
spnd tx genesis proposal-approve <chain-id> <proposal-id> --from user1 --keyring-backend test --chain-id spn
spnd tx genesis proposal-reject <chain-id> <proposal-id> --from user1 --keyring-backend test --chain-id spn

spnd q genesis current-genesis my-chain [—save-genesis <genesis-path>]
```