### PR TITLE
refactor: change the default ports for the blockchain

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,3 +7,11 @@ accounts:
 validator:
   name: user1
   staked: "100000000stake"
+servers:
+  rpc-address: "0.0.0.0:26651"
+  p2p-address: "0.0.0.0:26652"
+  prof-address: "0.0.0.0:6065"
+  grpc-address: "0.0.0.0:9098"
+  api-address: "0.0.0.0:1318"
+  frontend-address: "0.0.0.0:8082"
+  dev-ui-address: "0.0.0.0:12346"

--- a/integration/env_test.go
+++ b/integration/env_test.go
@@ -158,7 +158,7 @@ func (e env) Serve(msg string, path string, options ...execOption) (ok bool) {
 // before ctx canceled.
 func (e env) IsAppServed(ctx context.Context) error {
 	checkAlive := func() error {
-		ok, err := httpstatuschecker.Check(ctx, xurl.HTTP("localhost:1317")+"/node_info")
+		ok, err := httpstatuschecker.Check(ctx, xurl.HTTP("localhost:1318")+"/node_info")
 		if err == nil && !ok {
 			err = errors.New("app is not online")
 		}


### PR DESCRIPTION
Change the default ports used by the `spn` blockchain