### PR TITLE
fix(genesis): MsgProposalAddAccount verify address

### DIFF
--- a/x/genesis/types/proposal_add_account.go
+++ b/x/genesis/types/proposal_add_account.go
@@ -41,15 +41,19 @@ func NewProposalAddAccountPayload(
 func ValidateProposalPayloadAddAccount(payload *ProposalAddAccountPayload) error {
 	// Verify address is not empty
 	if payload.Address.Empty() {
-		return errors.New("Account address empty")
+		return errors.New("account address empty")
+	}
+
+	if _, err := sdk.AccAddressFromBech32(payload.Address.String()); err != nil {
+		return errors.New("invalid address")
 	}
 
 	// Check coin allocation validity
 	if !payload.Coins.IsValid() {
-		return fmt.Errorf("Coins allocation is invalid: %v", payload.Coins)
+		return fmt.Errorf("coins allocation is invalid: %v", payload.Coins)
 	}
 	if !payload.Coins.IsAllPositive() {
-		return fmt.Errorf("Coins allocation is non all positive: %v", payload.Coins)
+		return fmt.Errorf("coins allocation is non all positive: %v", payload.Coins)
 	}
 
 	return nil

--- a/x/genesis/types/proposal_test.go
+++ b/x/genesis/types/proposal_test.go
@@ -11,82 +11,87 @@ import (
 
 	"github.com/tendermint/spn/x/genesis/types"
 
-	"fmt"
 	"testing"
 )
 
 func TestNewProposalState(t *testing.T) {
 	// Can create a proposal state
 	ps := types.NewProposalState()
-	require.Equal(t, types.ProposalState_PENDING, ps.Status, "NewProposalState should create a pending proposal")
+	require.Equal(t, types.ProposalState_PENDING, ps.Status)
 
 	// Can change the state of the proposal
 	err := ps.SetStatus(types.ProposalState_APPROVED)
-	require.NoError(t, err, "SetStatus should set status of the proposal")
-	require.Equal(t, types.ProposalState_APPROVED, ps.Status, "SetStatus should set status of the proposal")
+	require.NoError(t, err)
+	require.Equal(t, types.ProposalState_APPROVED, ps.Status)
 }
 
 func TestNewProposalChange(t *testing.T) {
 	// Test valid payload
 	payload := spnmocks.MockProposalChangePayload()
 	err := types.ValidateProposalPayloadChange(payload)
-	require.NoError(t, err, "ValidateProposalPayloadChange should return no error")
+	require.NoError(t, err)
 
 	// Can create a proposal for a genesis change
 	_, err = types.NewProposalChange(
 		spnmocks.MockProposalInformation(),
 		payload,
 	)
-	require.NoError(t, err, "NewProposalChange should create a new proposal")
+	require.NoError(t, err)
 
 	// Prevent invalid change path
 	payload.ChangePath = []string{spnmocks.MockRandomString(5), "_"}
 	err = types.ValidateProposalPayloadChange(payload)
-	require.Error(t, err, "ValidateProposalPayloadChange should return error on invalid payload")
+	require.Error(t, err)
 
 	// Can't create a proposal with an invalid payload
 	_, err = types.NewProposalChange(
 		spnmocks.MockProposalInformation(),
 		payload,
 	)
-	require.Error(t, err, "NewProposalChange should prevent invalid payload")
+	require.Error(t, err)
 }
 
 func TestNewProposalAddAccount(t *testing.T) {
 	// Test valid payload
 	payload := spnmocks.MockProposalAddAccountPayload()
 	err := types.ValidateProposalPayloadAddAccount(payload)
-	require.NoError(t, err, fmt.Sprintf("ValidateProposalPayloadAddAccount should return no error: %v", err))
+	require.NoError(t, err)
 
 	// Can create a proposal for a genesis change
 	_, err = types.NewProposalAddAccount(
 		spnmocks.MockProposalInformation(),
 		payload,
 	)
-	require.NoError(t, err, "NewProposalAddAccount should create a new proposal")
+	require.NoError(t, err)
 
 	// Prevent add account with invalid address
 	payload.Address = sdk.AccAddress([]byte(""))
 	err = types.ValidateProposalPayloadAddAccount(payload)
-	require.Error(t, err, "ValidateProposalPayloadAddAccount should return error on invalid payload")
+	require.Error(t, err)
+
+	// Prevent add account with invalid address
+	payload.Address = sdk.AccAddress([]byte("InvalidAddress"))
+	err = types.ValidateProposalPayloadAddAccount(payload)
+	require.Error(t, err)
+
 
 	// Prevent invalid coins allocation
 	payload = spnmocks.MockProposalAddAccountPayload()
 	payload.Coins = []sdk.Coin{}
 	err = types.ValidateProposalPayloadAddAccount(payload)
-	require.Error(t, err, "ValidateProposalPayloadAddAccount should return error on invalid payload")
+	require.Error(t, err)
 
 	// Test with non sorted denomination
 	payload.Coins = []sdk.Coin{sdk.NewCoin("bbb", sdk.NewInt(10)), sdk.NewCoin("aaa", sdk.NewInt(10))}
 	err = types.ValidateProposalPayloadAddAccount(payload)
-	require.Error(t, err, "ValidateProposalPayloadAddAccount should return error on invalid payload")
+	require.Error(t, err)
 
 	// Can't create a proposal with an invalid payload
 	_, err = types.NewProposalAddAccount(
 		spnmocks.MockProposalInformation(),
 		payload,
 	)
-	require.Error(t, err, "NewProposalAddAccount should prevent invalid payload")
+	require.Error(t, err)
 }
 
 func TestNewProposalAddValidator(t *testing.T) {
@@ -95,31 +100,31 @@ func TestNewProposalAddValidator(t *testing.T) {
 	peer := "aaa@0.0.0.0:443"
 	payload.Peer = peer
 	err := types.ValidateProposalPayloadAddValidator(payload)
-	require.NoError(t, err, fmt.Sprintf("ValidateProposalPayloadAddValidator should return no error: %v", err))
+	require.NoError(t, err)
 
 	//Can get the peer
 	retrievedPeer := payload.GetPeer()
-	require.NoError(t, err, "GetPeer should get the validator peer")
-	require.Equal(t, peer, retrievedPeer, "GetPeer should get the validator peer")
+	require.NoError(t, err)
+	require.Equal(t, peer, retrievedPeer)
 
 	// Can create a proposal for a genesis change
 	_, err = types.NewProposalAddValidator(
 		spnmocks.MockProposalInformation(),
 		payload,
 	)
-	require.NoError(t, err, "NewProposalAddValidator should create a new proposal")
+	require.NoError(t, err)
 
 	// Invalid tx
 	payload = spnmocks.MockProposalAddValidatorPayload()
 	payload.GenTx.Body = nil
 	err = types.ValidateProposalPayloadAddValidator(payload)
-	require.Error(t, err, "ValidateProposalPayloadAddValidator should return error on invalid payload")
+	require.Error(t, err)
 
 	// No message
 	payload = spnmocks.MockProposalAddValidatorPayload()
 	payload.GenTx.Body.Messages = []*codectypes.Any{}
 	err = types.ValidateProposalPayloadAddValidator(payload)
-	require.Error(t, err, "ValidateProposalPayloadAddValidator should return error on invalid payload")
+	require.Error(t, err)
 
 	// Invalid message
 	payload = spnmocks.MockProposalAddValidatorPayload()
@@ -133,18 +138,18 @@ func TestNewProposalAddValidator(t *testing.T) {
 	)
 	payload.GenTx.Body.Messages[0], _ = codectypes.NewAnyWithValue(message)
 	err = types.ValidateProposalPayloadAddValidator(payload)
-	require.Error(t, err, "ValidateProposalPayloadAddValidator should return error on invalid payload")
+	require.Error(t, err)
 
 	// No peer
 	payload = spnmocks.MockProposalAddValidatorPayload()
 	payload.Peer = "" // Peer is inside the memo
 	err = types.ValidateProposalPayloadAddValidator(payload)
-	require.Error(t, err, "ValidateProposalPayloadAddValidator should return error on invalid payload")
+	require.Error(t, err)
 
 	// Can't create a proposal with an invalid payload
 	_, err = types.NewProposalAddValidator(
 		spnmocks.MockProposalInformation(),
 		payload,
 	)
-	require.Error(t, err, "NewProposalAddValidator should prevent invalid payload")
+	require.Error(t, err)
 }


### PR DESCRIPTION
Verify that the address provided to `MsgProposalAddAccount` contains a valid Bech32 format