### PR TITLE
test: remove require statement descriptions

### DIFF
--- a/x/chat/keeper/channel_test.go
+++ b/x/chat/keeper/channel_test.go
@@ -11,34 +11,34 @@ func TestCreateChannel(t *testing.T) {
 	ctx, k := spnmocks.MockChatContext()
 
 	// Channel count is 0 at initialization
-	require.Zero(t, k.GetChannelCount(ctx), "Channel count must be 0 at initialization")
+	require.Zero(t, k.GetChannelCount(ctx))
 
 	// Cannot find a non existing channel
 	_, found := k.GetChannel(ctx, 0)
-	require.False(t, found, "GetChannel should return found to as false if the channel doesn't exist")
+	require.False(t, found)
 
 	// A channel can be appended and retrieved
 	newChannel := spnmocks.MockChannel()
 	k.CreateChannel(ctx, newChannel)
 	retrieved, found := k.GetChannel(ctx, 0)
-	require.True(t, found, "An appended channel should be retrieved")
-	require.Equal(t, newChannel.Title, retrieved.Title, "GetChannel should retrieve the appended channel")
-	require.Equal(t, int32(1), k.GetChannelCount(ctx), "Channel count must be 1 after a channel has been appended")
+	require.True(t, found)
+	require.Equal(t, newChannel.Title, retrieved.Title)
+	require.Equal(t, int32(1), k.GetChannelCount(ctx))
 
 	// A second channel can be appended an retrieved
 	newChannel = spnmocks.MockChannel()
 	k.CreateChannel(ctx, newChannel)
 	retrieved, found = k.GetChannel(ctx, 1)
-	require.True(t, found, "An appended channel should be retrieved")
-	require.Equal(t, newChannel.Title, retrieved.Title, "GetChannel should retrieve the appended channel")
+	require.True(t, found)
+	require.Equal(t, newChannel.Title, retrieved.Title)
 
 	// Prevent a invalid user to create a channel
 	newChannel = spnmocks.MockChannel()
 	newChannel.Creator = "invalid_identifier"
 	err := k.CreateChannel(ctx, newChannel)
-	require.Error(t, err, "CreateChannel should prevent an invalid user to create a channel")
+	require.Error(t, err)
 
 	// Can retrieve all the channels
 	channels := k.GetAllChannels(ctx)
-	require.Equal(t, 2, len(channels), "GetAllChannels should find the channels in the store")
+	require.Equal(t, 2, len(channels))
 }

--- a/x/chat/keeper/message_test.go
+++ b/x/chat/keeper/message_test.go
@@ -14,70 +14,74 @@ func TestAppendMessageToChannel(t *testing.T) {
 	// Channel not found if the channel is not added yet
 	message := spnmocks.MockMessageWithPoll(0, []string{"chocolate", "cake", "cookie", "icecream", "oreo"})
 	channelFound, _ := k.AppendMessageToChannel(ctx, message)
-	require.False(t, channelFound, "AppendMessageToChannel should return false on a non existing channel")
+	require.False(t, channelFound)
 
 	// Create a channel
 	k.CreateChannel(ctx, spnmocks.MockChannel())
 	channel, _ := k.GetChannel(ctx, 0)
-	require.Zero(t, channel.MessageCount, "A new channel should have 0 message")
+	require.Zero(t, channel.MessageCount)
 
 	// Cannot find a non existing message
 	_, messageFound := k.GetMessageFromIndex(ctx, 0, 0)
-	require.False(t, messageFound, "GetMessageFromIndex should return false on a non existing message")
+	require.False(t, messageFound)
 
 	// Append a message to a channel
 	channelFound, _ = k.AppendMessageToChannel(ctx, message)
-	require.True(t, channelFound, "AppendMessageToChannel should return true if the channel exists")
+	require.True(t, channelFound)
 	channel, _ = k.GetChannel(ctx, 0)
-	require.Equal(t, int32(1), channel.MessageCount, "The channel should have 1 message")
+	require.Equal(t, int32(1), channel.MessageCount)
 
 	// Can retrieve the message
 	retrieved, messageFound := k.GetMessageFromIndex(ctx, 0, 0)
-	require.True(t, messageFound, "GetMessageFromIndex should return true if the message exists")
-	require.Equal(t, message.Content, retrieved.Content, "The retrieved message should be the appended message")
-	require.Equal(t, 5, len(retrieved.Poll.Options), "The retrieved message should have a poll")
+	require.True(t, messageFound)
+	require.Equal(t, message.Content, retrieved.Content)
+	require.Equal(t, 5, len(retrieved.Poll.Options))
 
 	// Can retrieve the message with its ID
 	messageID := types.GetMessageIDFromChannelIDandIndex(0, 0)
 	retrieved, messageFound = k.GetMessageByID(ctx, messageID)
-	require.True(t, messageFound, "GetMessageFromID should return true if the message exists")
-	require.Equal(t, message.Content, retrieved.Content, "The retrieved message should be the appended message")
+	require.True(t, messageFound)
+	require.Equal(t, message.Content, retrieved.Content)
 
 	// Prevent a invalid user to append a message
 	message = spnmocks.MockMessage(0)
 	message.Creator = "invalid_identifier"
 	_, err := k.AppendMessageToChannel(ctx, message)
-	require.Error(t, err, "AppendMessageToChannel should prevent an invalid user to append a message")
+	require.Error(t, err)
 
 	// Cannot append a vote in a non existing message
-	messageFound, err = k.AppendVoteToPoll(ctx, types.GetMessageIDFromChannelIDandIndex(0, 1), spnmocks.MockVote(0))
-	require.NoError(t, err, "AppendVoteToPoll non existing message shouldn't be an error")
-	require.False(t, messageFound, "AppendVoteToPoll should return false on a non existing message")
+	messageFound, err = k.AppendVoteToPoll(
+		ctx,
+		types.GetMessageIDFromChannelIDandIndex(0, 1),
+		spnmocks.MockVote(0),
+	)
+	require.NoError(t, err)
+	require.False(t, messageFound)
 
 	// Can append a vote to the poll of a message
 	messageFound, err = k.AppendVoteToPoll(ctx, messageID, spnmocks.MockVote(0))
-	require.NoError(t, err, "AppendVoteToPoll shouldn't return an error (0)")
+	require.NoError(t, err)
 	messageFound, err = k.AppendVoteToPoll(ctx, messageID, spnmocks.MockVote(1))
-	require.NoError(t, err, "AppendVoteToPoll shouldn't return an error (1)")
+	require.NoError(t, err)
 	messageFound, err = k.AppendVoteToPoll(ctx, messageID, spnmocks.MockVote(2))
-	require.NoError(t, err, "AppendVoteToPoll shouldn't return an error (2)")
+	require.NoError(t, err)
 	messageFound, err = k.AppendVoteToPoll(ctx, messageID, spnmocks.MockVote(3))
-	require.NoError(t, err, "AppendVoteToPoll shouldn't return an error (3)")
+	require.NoError(t, err)
 	messageFound, err = k.AppendVoteToPoll(ctx, messageID, spnmocks.MockVote(4))
-	require.NoError(t, err, "AppendVoteToPoll shouldn't return an error (4)")
-	require.True(t, messageFound, "UpdateMessagePoll should return true if the message exists")
+	require.NoError(t, err)
+	require.True(t, messageFound)
 	retrieved, _ = k.GetMessageByID(ctx, messageID)
-	require.Equal(t, 5, len(retrieved.Poll.Votes), "AppendVoteToPoll should append votes")
+	require.Equal(t, 5, len(retrieved.Poll.Votes))
 
 	// AppendVoteToPoll fails if invalid vote
 	_, err = k.AppendVoteToPoll(ctx, messageID, spnmocks.MockVote(5))
-	require.Error(t, err, "AppendVoteToPoll should prevent invalid vote")
+	require.Error(t, err)
 
 	// AppendVoteToPoll prevents a invalid user to vote
 	vote := spnmocks.MockVote(0)
 	vote.Creator = "invalid_identifier"
 	_, err = k.AppendVoteToPoll(ctx, messageID, vote)
-	require.Error(t, err, "AppendVoteToPoll should prevent invalid vote")
+	require.Error(t, err)
 
 	// Can retrieve all message in a poll
 	message = spnmocks.MockMessage(0)
@@ -87,14 +91,14 @@ func TestAppendMessageToChannel(t *testing.T) {
 	message = spnmocks.MockMessage(0)
 	k.AppendMessageToChannel(ctx, message)
 	_, channelFound = k.GetAllMessagesFromChannel(ctx, 1)
-	require.False(t, channelFound, "GetAllMessagesFromChannel should return false on non existing channel")
+	require.False(t, channelFound)
 
 	messages, channelFound := k.GetAllMessagesFromChannel(ctx, 0)
-	require.True(t, channelFound, "GetAllMessagesFromChannel should return true if the channel exists")
-	require.Equal(t, int32(0), messages[0].MessageIndex, "GetAllMessagesFromChannel should return messages in the correct order")
-	require.Equal(t, int32(1), messages[1].MessageIndex, "GetAllMessagesFromChannel should return messages in the correct order")
-	require.Equal(t, int32(2), messages[2].MessageIndex, "GetAllMessagesFromChannel should return messages in the correct order")
-	require.Equal(t, int32(3), messages[3].MessageIndex, "GetAllMessagesFromChannel should return messages in the correct order")
+	require.True(t, channelFound)
+	require.Equal(t, int32(0), messages[0].MessageIndex)
+	require.Equal(t, int32(1), messages[1].MessageIndex)
+	require.Equal(t, int32(2), messages[2].MessageIndex)
+	require.Equal(t, int32(3), messages[3].MessageIndex)
 
 	// Can retrieve several messages with message IDs
 	var messageIDs []string
@@ -103,9 +107,9 @@ func TestAppendMessageToChannel(t *testing.T) {
 	}
 	messageIDs = append(messageIDs, types.GetMessageIDFromChannelIDandIndex(1, 0))
 	messages = k.GetMessagesByIDs(ctx, messageIDs)
-	require.Equal(t, 4, len(messages), "GetMessagesFromIDs should find the exact number of message")
-	require.Equal(t, int32(3), messages[0].MessageIndex, "GetMessagesFromIDs should return messages in the correct order")
-	require.Equal(t, int32(2), messages[1].MessageIndex, "GetMessagesFromIDs should return messages in the correct order")
-	require.Equal(t, int32(1), messages[2].MessageIndex, "GetMessagesFromIDs should return messages in the correct order")
-	require.Equal(t, int32(0), messages[3].MessageIndex, "GetMessagesFromIDs should return messages in the correct order")
+	require.Equal(t, 4, len(messages))
+	require.Equal(t, int32(3), messages[0].MessageIndex)
+	require.Equal(t, int32(2), messages[1].MessageIndex)
+	require.Equal(t, int32(1), messages[2].MessageIndex)
+	require.Equal(t, int32(0), messages[3].MessageIndex)
 }

--- a/x/chat/keeper/tag_reference_test.go
+++ b/x/chat/keeper/tag_reference_test.go
@@ -33,23 +33,23 @@ func TestGetTagReferencesFromChannel(t *testing.T) {
 	k.AppendMessageToChannel(ctx, message)
 
 	fooReferences := k.GetTagReferencesFromChannel(ctx, "foo", 0)
-	require.Equal(t, 3, len(fooReferences), "GetTagReferencesFromChannel should find 3 foo references")
-	require.Equal(t, message0ID, fooReferences[0], "GetTagReferencesFromChannel should return reference message ID")
-	require.Equal(t, message1ID, fooReferences[1], "GetTagReferencesFromChannel should return reference message ID")
-	require.Equal(t, message3ID, fooReferences[2], "GetTagReferencesFromChannel should return reference message ID")
+	require.Equal(t, 3, len(fooReferences))
+	require.Equal(t, message0ID, fooReferences[0])
+	require.Equal(t, message1ID, fooReferences[1])
+	require.Equal(t, message3ID, fooReferences[2])
 
 	barReferences := k.GetTagReferencesFromChannel(ctx, "bar", 0)
-	require.Equal(t, 3, len(barReferences), "GetTagReferencesFromChannel should find 3 bar references")
-	require.Equal(t, message0ID, barReferences[0], "GetTagReferencesFromChannel should return reference message ID")
-	require.Equal(t, message1ID, barReferences[1], "GetTagReferencesFromChannel should return reference message ID")
-	require.Equal(t, message2ID, barReferences[2], "GetTagReferencesFromChannel should return reference message ID")
+	require.Equal(t, 3, len(barReferences))
+	require.Equal(t, message0ID, barReferences[0])
+	require.Equal(t, message1ID, barReferences[1])
+	require.Equal(t, message2ID, barReferences[2])
 
 	foobarReferences := k.GetTagReferencesFromChannel(ctx, "foo-bar", 0)
-	require.Equal(t, 1, len(foobarReferences), "GetTagReferencesFromChannel should find 1 foo-bar reference")
-	require.Equal(t, message0ID, foobarReferences[0], "GetTagReferencesFromChannel should return reference message ID")
+	require.Equal(t, 1, len(foobarReferences))
+	require.Equal(t, message0ID, foobarReferences[0])
 
 	barfooReferences := k.GetTagReferencesFromChannel(ctx, "bar-foo", 0)
-	require.Equal(t, 0, len(barfooReferences), "GetTagReferencesFromChannel should find 0 bar-foo reference")
+	require.Equal(t, 0, len(barfooReferences))
 
 	// Can get all tag references in all channels
 	k.CreateChannel(ctx, spnmocks.MockChannel())
@@ -62,10 +62,10 @@ func TestGetTagReferencesFromChannel(t *testing.T) {
 	k.AppendMessageToChannel(ctx, message)
 
 	fooReferences = k.GetAllTagReferences(ctx, "foo")
-	require.Equal(t, 5, len(fooReferences), "GetAllTagReferences should find 5 foo references")
-	require.Equal(t, message0ID, fooReferences[0], "GetAllTagReferences should return reference message ID")
-	require.Equal(t, message1ID, fooReferences[1], "GetAllTagReferences should return reference message ID")
-	require.Equal(t, message3ID, fooReferences[2], "GetAllTagReferences should return reference message ID")
-	require.Equal(t, message4ID, fooReferences[3], "GetAllTagReferences should return reference message ID")
-	require.Equal(t, message5ID, fooReferences[4], "GetAllTagReferences should return reference message ID")
+	require.Equal(t, 5, len(fooReferences))
+	require.Equal(t, message0ID, fooReferences[0])
+	require.Equal(t, message1ID, fooReferences[1])
+	require.Equal(t, message3ID, fooReferences[2])
+	require.Equal(t, message4ID, fooReferences[3])
+	require.Equal(t, message5ID, fooReferences[4])
 }

--- a/x/chat/types/channel_test.go
+++ b/x/chat/types/channel_test.go
@@ -17,8 +17,8 @@ func TestNewChannel(t *testing.T) {
 		"bar",
 		nil,
 	)
-	require.NoError(t, err, "NewChannel should create a new channel")
-	require.Zero(t, channel.MessageCount, "NewChannel should create a channel with 0 message")
+	require.NoError(t, err)
+	require.Zero(t, channel.MessageCount)
 
 	// Can create a channel with payload
 	payload := spnmocks.MockPayload()
@@ -29,7 +29,7 @@ func TestNewChannel(t *testing.T) {
 		"bar",
 		payload,
 	)
-	require.NoError(t, err, "NewChannel should create a new channel")
+	require.NoError(t, err)
 
 	// Prevent creating a channel with an invalid name
 	bigName := spnmocks.MockRandomString(types.ChannelTitleMaxLength + 1)
@@ -40,7 +40,7 @@ func TestNewChannel(t *testing.T) {
 		"bar",
 		nil,
 	)
-	require.Error(t, err, "NewChannel should prevent creating a channel with an invalid name")
+	require.Error(t, err)
 
 	// Prevent creating a channel with an invalid subject
 	bigSubject := spnmocks.MockRandomString(types.ChannelDescriptionMaxLength + 1)
@@ -51,7 +51,7 @@ func TestNewChannel(t *testing.T) {
 		bigSubject,
 		nil,
 	)
-	require.Error(t, err, "NewChannel should prevent creating a channel with an invalid subject")
+	require.Error(t, err)
 
 }
 
@@ -67,11 +67,11 @@ func TestIncrementMessageCount(t *testing.T) {
 
 	oldCount := channel.MessageCount
 	channel.IncrementMessageCount()
-	require.Equal(t, oldCount+1, channel.MessageCount, "IncrementMessageCount should increment the message count")
+	require.Equal(t, oldCount+1, channel.MessageCount)
 
 	// Test from a random number
 	channel.MessageCount = rand.Int31()
 	oldCount = channel.MessageCount
 	channel.IncrementMessageCount()
-	require.Equal(t, oldCount+1, channel.MessageCount, "IncrementMessageCount should increment the message count")
+	require.Equal(t, oldCount+1, channel.MessageCount)
 }

--- a/x/chat/types/message_test.go
+++ b/x/chat/types/message_test.go
@@ -20,8 +20,8 @@ func TestNewMessage(t *testing.T) {
 		[]string{},
 		nil,
 	)
-	require.NoError(t, err, "NewMessage should create a new message")
-	require.False(t, message.HasPoll, "NewMessage with no poll options should not create a poll")
+	require.NoError(t, err)
+	require.False(t, message.HasPoll)
 
 	// Can create a message
 	payload := spnmocks.MockPayload()
@@ -35,7 +35,7 @@ func TestNewMessage(t *testing.T) {
 		[]string{},
 		payload,
 	)
-	require.NoError(t, err, "NewMessage should create a new message")
+	require.NoError(t, err)
 
 	// Create create a message with a poll
 	pollOptions := []string{"coffee", "tea", "water", "beer"}
@@ -49,9 +49,9 @@ func TestNewMessage(t *testing.T) {
 		pollOptions,
 		nil,
 	)
-	require.NoError(t, err, "NewMessage should create a new message")
-	require.True(t, message.HasPoll, "NewMessage with poll options should create a poll")
-	require.Equal(t, pollOptions, message.Poll.Options, "NewMessage with poll options should create a poll with same options")
+	require.NoError(t, err)
+	require.True(t, message.HasPoll)
+	require.Equal(t, pollOptions, message.Poll.Options)
 
 	// Prevent creating a message with an invalid content
 	bigContent := spnmocks.MockRandomString(types.MessageContentMaxLength + 1)
@@ -65,7 +65,7 @@ func TestNewMessage(t *testing.T) {
 		[]string{},
 		nil,
 	)
-	require.Error(t, err, "NewMessage should prevent creating a message with an invalid content")
+	require.Error(t, err)
 
 	// Prevent creating a message with an invalid tag
 	message, err = types.NewMessage(
@@ -78,6 +78,6 @@ func TestNewMessage(t *testing.T) {
 		[]string{},
 		payload,
 	)
-	require.Error(t, err, "NewMessage should prevent creating a message with an invalid tag")
+	require.Error(t, err)
 
 }

--- a/x/chat/types/messages_test.go
+++ b/x/chat/types/messages_test.go
@@ -18,9 +18,9 @@ func TestMsgCreateChannel(t *testing.T) {
 		"bar",
 		nil,
 	)
-	require.NoError(t, err, "NewMsgCreateChannel should create a MsgCreateChannel")
+	require.NoError(t, err)
 	err = msg.ValidateBasic()
-	require.NoError(t, err, "NewMsgCreateChannel should create a valid MsgCreateChannel")
+	require.NoError(t, err)
 
 	// Can create a MsgCreateChannel with payload
 	payload := spnmocks.MockPayload()
@@ -30,9 +30,9 @@ func TestMsgCreateChannel(t *testing.T) {
 		"bar",
 		payload,
 	)
-	require.NoError(t, err, "NewMsgCreateChannel should create a MsgCreateChannel")
+	require.NoError(t, err)
 	err = msg.ValidateBasic()
-	require.NoError(t, err, "NewMsgCreateChannel should create a valid MsgCreateChannel")
+	require.NoError(t, err)
 }
 
 func TestMsgSendMessage(t *testing.T) {
@@ -47,9 +47,9 @@ func TestMsgSendMessage(t *testing.T) {
 		[]string{},
 		nil,
 	)
-	require.NoError(t, err, "MsgSendMessage should create a MsgSendMessage")
+	require.NoError(t, err)
 	err = msg.ValidateBasic()
-	require.NoError(t, err, "MsgSendMessage should create a valid MsgSendMessage")
+	require.NoError(t, err)
 
 	// Can create a MsgSendMessage with payload
 	payload := spnmocks.MockPayload()
@@ -61,9 +61,9 @@ func TestMsgSendMessage(t *testing.T) {
 		[]string{},
 		payload,
 	)
-	require.NoError(t, err, "MsgSendMessage should create a MsgSendMessage")
+	require.NoError(t, err)
 	err = msg.ValidateBasic()
-	require.NoError(t, err, "MsgSendMessage should create a valid MsgSendMessage")
+	require.NoError(t, err)
 }
 
 func TestMsgVotePoll(t *testing.T) {
@@ -77,9 +77,9 @@ func TestMsgVotePoll(t *testing.T) {
 		0,
 		nil,
 	)
-	require.NoError(t, err, "MsgVotePoll should create a MsgVotePoll")
+	require.NoError(t, err)
 	err = msg.ValidateBasic()
-	require.NoError(t, err, "MsgVotePoll should create a valid MsgVotePoll")
+	require.NoError(t, err)
 
 	// Can create a MsgVotePoll
 	payload := spnmocks.MockPayload()
@@ -90,7 +90,7 @@ func TestMsgVotePoll(t *testing.T) {
 		0,
 		payload,
 	)
-	require.NoError(t, err, "MsgVotePoll should create a MsgVotePoll")
+	require.NoError(t, err)
 	err = msg.ValidateBasic()
-	require.NoError(t, err, "MsgVotePoll should create a valid MsgVotePoll")
+	require.NoError(t, err)
 }

--- a/x/chat/types/poll_test.go
+++ b/x/chat/types/poll_test.go
@@ -12,9 +12,9 @@ func TestNewPoll(t *testing.T) {
 	// Can create a poll
 	pollOptions := []string{"coffee", "tea", "water", "beer"}
 	poll, err := types.NewPoll(pollOptions)
-	require.NoError(t, err, "NewPoll should create a new poll")
-	require.Equal(t, pollOptions, poll.Options, "NewPoll should create a new poll with options provided")
-	require.Zero(t, len(poll.Votes), "NewPoll should create a new poll with no vote")
+	require.NoError(t, err)
+	require.Equal(t, pollOptions, poll.Options)
+	require.Zero(t, len(poll.Votes))
 }
 
 func TestNewVote(t *testing.T) {
@@ -23,7 +23,7 @@ func TestNewVote(t *testing.T) {
 	// Can create a vote with payload
 	payload := spnmocks.MockPayload()
 	_, err := types.NewVote(user, 0, payload)
-	require.NoError(t, err, "NewVote should create a new vote")
+	require.NoError(t, err)
 }
 
 func TestAppendVote(t *testing.T) {
@@ -34,26 +34,26 @@ func TestAppendVote(t *testing.T) {
 	// Allow to append a vote
 	vote, _ := types.NewVote(user, 0, nil)
 	err := poll.AppendVote(&vote)
-	require.NoError(t, err, "AppendVote should append a vote")
-	require.Equal(t, 1, len(poll.Votes), "AppendVote should append a vote")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(poll.Votes))
 
 	// Allow to append a vote from another user
 	user2 := spnmocks.MockUser()
 	vote2, _ := types.NewVote(user2, 2, nil)
 	err = poll.AppendVote(&vote2)
-	require.NoError(t, err, "AppendVote should append a second vote")
-	require.Equal(t, 2, len(poll.Votes), "AppendVote should append a second vote")
+	require.NoError(t, err)
+	require.Equal(t, 2, len(poll.Votes))
 
 	// Prevent appending invalid valid
 	user3 := spnmocks.MockUser()
 	vote3, _ := types.NewVote(user3, int32(len(pollOptions)), nil)
 	err = poll.AppendVote(&vote3)
-	require.Error(t, err, "AppendVote should prevent append an invalid vote")
+	require.Error(t, err)
 
 	// Prevent appending a vote from the same user
 	vote4, _ := types.NewVote(user, 0, nil)
 	err = poll.AppendVote(&vote4)
-	require.Error(t, err, "AppendVote should prevent append a vote from a user who already voted")
+	require.Error(t, err)
 }
 
 func TestHasUserVoted(t *testing.T) {
@@ -63,15 +63,15 @@ func TestHasUserVoted(t *testing.T) {
 
 	// Should return false if no vote
 	voted, err := poll.HasUserVoted(user)
-	require.NoError(t, err, "HasUserVoted should return false")
-	require.False(t, voted, "HasUserVoted should return false")
+	require.NoError(t, err)
+	require.False(t, voted)
 
 	// Should return true if voted
 	vote, _ := types.NewVote(user, 0, nil)
 	poll.AppendVote(&vote)
 	voted, err = poll.HasUserVoted(user)
-	require.NoError(t, err, "HasUserVoted with vote should return true")
-	require.True(t, voted, "HasUserVoted with vote should return true")
+	require.NoError(t, err)
+	require.True(t, voted)
 
 }
 
@@ -82,13 +82,13 @@ func TestGetUserVote(t *testing.T) {
 
 	// Should return error if no vote
 	_, err := poll.GetUserVote(user)
-	require.Error(t, err, "GetUserVote with no vote should return an error")
+	require.Error(t, err)
 
 	// Should return the vote
 	vote, _ := types.NewVote(user, 0, nil)
 	poll.AppendVote(&vote)
 	retrieved, err := poll.GetUserVote(user)
-	require.NoError(t, err, "GetUserVote should return the vote")
-	require.Equal(t, vote, *retrieved, "Not equal")
+	require.NoError(t, err)
+	require.Equal(t, vote, *retrieved)
 
 }

--- a/x/genesis/types/chain_test.go
+++ b/x/genesis/types/chain_test.go
@@ -22,8 +22,8 @@ func TestNewChain(t *testing.T) {
 		time.Now(),
 		spnmocks.MockGenesis(),
 	)
-	require.NoError(t, err, "NewChain should create a new chain")
-	require.Equal(t, 0, len(chain.Peers), "chain should have no peer when create")
+	require.NoError(t, err)
+	require.Equal(t, 0, len(chain.Peers))
 
 	// The chain ID should be added to the genesis of the chain
 	chainID := chain.ChainID
@@ -36,8 +36,8 @@ func TestNewChain(t *testing.T) {
 	peer2 := spnmocks.MockRandomString(20)
 	chain.AppendPeer(peer1)
 	chain.AppendPeer(peer2)
-	require.Equal(t, 2, len(chain.Peers), "AppendPeer should append new peers to the chain")
-	require.Equal(t, []string{peer1, peer2}, chain.Peers, "AppendPeer should append new peers to the chain")
+	require.Equal(t, 2, len(chain.Peers))
+	require.Equal(t, []string{peer1, peer2}, chain.Peers)
 
 	// Prevent creating a chain with a invalid name
 	_, err = types.NewChain(
@@ -48,7 +48,7 @@ func TestNewChain(t *testing.T) {
 		time.Now(),
 		spnmocks.MockGenesis(),
 	)
-	require.Error(t, err, "NewChain should prevent creating chains with an invalid name")
+	require.Error(t, err)
 
 	// Prevent creating a chain with a invalid genesis
 	_, err = types.NewChain(
@@ -59,7 +59,7 @@ func TestNewChain(t *testing.T) {
 		time.Now(),
 		[]byte(spnmocks.MockRandomString(500)),
 	)
-	require.Error(t, err, "NewChain should prevent creating chains with an invalid genesis")
+	require.Error(t, err)
 
 	var genesisObject tmtypes.GenesisDoc
 	genesisObject.ConsensusParams = tmtypes.DefaultConsensusParams()
@@ -76,5 +76,5 @@ func TestNewChain(t *testing.T) {
 		time.Now(),
 		genesis,
 	)
-	require.Error(t, err, "NewChain should prevent creating chains with an invalid genesis")
+	require.Error(t, err)
 }

--- a/x/identity/keeper/keeper_test.go
+++ b/x/identity/keeper/keeper_test.go
@@ -12,30 +12,30 @@ func TestSetUsername(t *testing.T) {
 
 	// The username should be the address if it is not set
 	username, _ := k.GetUsernameFromAddress(ctx, address)
-	require.Equal(t, address.String(), username, "GetUsernameFromAddress should return the address if no username")
+	require.Equal(t, address.String(), username)
 
 	// Prevent setting an invalid username
 	err := k.SetUsername(ctx, address, "foo!")
-	require.Error(t, err, "SetUsername should prevent using an invalid username")
+	require.Error(t, err)
 
 	// Can set a username
 	err = k.SetUsername(ctx, address, "foo")
-	require.NoError(t, err, "SetUsername allows to set a valid username")
+	require.NoError(t, err)
 
 	// Username can be retrieve
 	username, _ = k.GetUsernameFromAddress(ctx, address)
-	require.Equal(t, "foo", username, "GetUsernameFromAddress should return the new username")
+	require.Equal(t, "foo", username)
 
 	// Username can be retrieved from the identifier
 	id, _ := k.GetIdentifier(ctx, address)
 	username, _ = k.GetUsername(ctx, id)
-	require.Equal(t, "foo", username, "GetUsername should return the new username")
+	require.Equal(t, "foo", username)
 
 	// Can set a new username
 	err = k.SetUsername(ctx, address, "bar")
-	require.NoError(t, err, "SetUsername allows to set a valid username")
+	require.NoError(t, err)
 	username, _ = k.GetUsernameFromAddress(ctx, address)
-	require.Equal(t, "bar", username, "GetUsername should return the new username")
+	require.Equal(t, "bar", username)
 }
 
 func TestGetIdentifier(t *testing.T) {
@@ -44,7 +44,7 @@ func TestGetIdentifier(t *testing.T) {
 
 	// Return the address
 	identifier, _ := k.GetIdentifier(ctx, address)
-	require.Equal(t, address.String(), identifier, "GetIdentifier should return the address")
+	require.Equal(t, address.String(), identifier)
 }
 
 func TestGetAddresses(t *testing.T) {
@@ -53,8 +53,8 @@ func TestGetAddresses(t *testing.T) {
 
 	// Return only the address provided
 	addresses, _ := k.GetAddresses(ctx, address.String())
-	require.Equal(t, 1, len(addresses), "GetAddresses shoudl only return the address provided")
-	require.True(t, address.Equals(addresses[0]), "GetAddresses shoudl only return the address provided")
+	require.Equal(t, 1, len(addresses))
+	require.True(t, address.Equals(addresses[0]))
 }
 
 func TestIdentityExists(t *testing.T) {
@@ -63,9 +63,9 @@ func TestIdentityExists(t *testing.T) {
 	// Return true if the identifier is an address
 	address := spnmocks.MockAccAddress()
 	exists, _ := k.IdentityExists(ctx, address.String())
-	require.True(t, exists, "Any Bech32 address should be a valid identifier")
+	require.True(t, exists)
 
 	// Return false if not an address
 	exists, _ = k.IdentityExists(ctx, "foo")
-	require.False(t, exists, "A non Bech32 address should not be a valid identifier")
+	require.False(t, exists)
 }

--- a/x/identity/types/messages_test.go
+++ b/x/identity/types/messages_test.go
@@ -12,16 +12,16 @@ func TestMsgSetUsername(t *testing.T) {
 	// Can create a message with a valid username
 	addr := spnmocks.MockAccAddress()
 	_, err := types.NewMsgSetUsername(addr, "foo-bar_40foo_01")
-	require.NoError(t, err, "NewMsgSetUsername should create a MsgSetUsername")
+	require.NoError(t, err)
 	_, err = types.NewMsgSetUsername(addr, spnmocks.MockRandomString(types.UsernameMaxLength))
-	require.NoError(t, err, "NewMsgSetUsername should create a MsgSetUsername")
+	require.NoError(t, err)
 
 	// Prevent to create message with invalid name
 	_, err = types.NewMsgSetUsername(addr, "")
-	require.Error(t, err, "NewMsgSetUsername prevent an invalid username")
+	require.Error(t, err)
 	_, err = types.NewMsgSetUsername(addr, "foo!")
-	require.Error(t, err, "NewMsgSetUsername prevent an invalid username")
+	require.Error(t, err)
 	_, err = types.NewMsgSetUsername(addr, spnmocks.MockRandomString(types.UsernameMaxLength+1))
-	require.Error(t, err, "NewMsgSetUsername prevent an invalid username")
+	require.Error(t, err)
 
 }


### PR DESCRIPTION
Remove all description strings in `require` statement. These strings don't provide additional information when the test fail and complicate the visibility of the code