### PR TITLE
fix(genesis): add peer in the chain information when a validator is approved

### DIFF
--- a/x/genesis/keeper/approval.go
+++ b/x/genesis/keeper/approval.go
@@ -95,7 +95,13 @@ func (k Keeper) applyProposalAddValidator(ctx sdk.Context, chainID string, paylo
 		panic(fmt.Errorf("A ProposalAddValidator contains a invalid payload %v", err.Error()))
 	}
 
+	// Set the new validator
 	k.SetValidator(ctx, chainID, valAddr)
+
+	// Add the peer inside the payload to the chain peer id
+	chain, _ := k.GetChain(ctx, chainID)
+	chain.Peers = append(chain.Peers, payload.Peer)
+	k.SetChain(ctx, chain)
 
 	return nil
 }

--- a/x/genesis/keeper/approval_test.go
+++ b/x/genesis/keeper/approval_test.go
@@ -128,6 +128,10 @@ func TestApplyProposalAddValidator(t  *testing.T) {
 	isValidatorSet := k.IsValidatorSet(ctx, chainID, valAddress)
 	require.True(t, isValidatorSet)
 
+	// The peer ids of the chain is updated upon validator approval
+	retrievedChain, _ := k.GetChain(ctx, chainID)
+	require.Contains(t, retrievedChain.Peers, payload.Peer)
+
 	// Prevent perform on non existent chain
 	err = k.ApplyProposalApproval(ctx, spnmocks.MockRandomAlphaString(5), *proposal)
 	require.Error(t, err)


### PR DESCRIPTION
Add the peer in chain information so that all peers can be fetched with `ShowChain`