### PR TITLE
feat(genesis): verify account funds for validator self-delegation

### DIFF
--- a/internal/testing/mock_genesis.go
+++ b/internal/testing/mock_genesis.go
@@ -160,9 +160,12 @@ func MockProposalChangePayload() *types.ProposalChangePayload {
 
 // MockProposalAddAccountPayload mocks a valid payload
 func MockProposalAddAccountPayload() *types.ProposalAddAccountPayload {
+	stake := sdk.NewCoin("stake", sdk.NewInt(100000))
+	token := sdk.NewCoin("token", sdk.NewInt(100000))
+
 	return types.NewProposalAddAccountPayload(
 		MockAccAddress(),
-		MockCoins(),
+		sdk.NewCoins(stake, token),
 	)
 }
 
@@ -184,13 +187,19 @@ func MockProposalInformation() *types.ProposalInformation {
 
 // MockGenTx mocks a gentx transaction
 func MockGenTx() tx.Tx {
+	selfDelegation := sdk.NewCoin("stake", sdk.NewInt(10000))
+	return MockGenTxWithDelegation(selfDelegation)
+}
+
+// MockGenTxWithDelegation mocks a gentx transaction with a custom self-delegation
+func MockGenTxWithDelegation(selfDelegation sdk.Coin) tx.Tx {
 	privKey, opAddress := MockValAddress()
 
 	// Create validator message
 	message := staking.NewMsgCreateValidator(
 		opAddress,
 		MockPubKey(),
-		MockCoin(),
+		selfDelegation,
 		MockDescription(),
 		MockCommissionRates(),
 		sdk.NewInt(1),

--- a/x/genesis/handler_test.go
+++ b/x/genesis/handler_test.go
@@ -258,9 +258,11 @@ func TestHandleMsgApprove(t *testing.T) {
 
 	// Create a add validator proposal
 	addValidatorPayload := spnmocks.MockProposalAddValidatorPayload()
+	addAccountPayload = spnmocks.MockProposalAddAccountPayload()
 	createValidatorMessage, _ := addValidatorPayload.GetCreateValidatorMessage()
 	valAddress, _ := sdk.ValAddressFromBech32(createValidatorMessage.ValidatorAddress)
-	k.SetAccount(ctx, chainID, sdk.AccAddress(valAddress))	// Simulate account address already being provided
+	addAccountPayload.Address = sdk.AccAddress(valAddress)
+	k.SetAccount(ctx, chainID, addAccountPayload.Address, addAccountPayload)	// Simulate account address already being provided
 	msgProposalValidator := types.NewMsgProposalAddValidator(
 		chainID,
 		proposalCreator,

--- a/x/genesis/keeper/account.go
+++ b/x/genesis/keeper/account.go
@@ -5,14 +5,19 @@ import (
 	"github.com/tendermint/spn/x/genesis/types"
 )
 
-// We just need a value to store in the store
-var accountSet []byte = []byte("1")
-
 // SetAccount set an account address that exists in the genesis of a chain
 // This allows us to retrieve in a constant time the current accounts of a genesis to perform verifications
-func (k Keeper) SetAccount(ctx sdk.Context, chainID string, address sdk.AccAddress) {
+func (k Keeper) SetAccount(ctx sdk.Context, chainID string, address sdk.AccAddress, payload *types.ProposalAddValidatorPayload) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set(types.GetAccountKey(chainID, address), accountSet)
+
+	bz := k.cdc.MustMarshalBinaryBare(payload)
+	store.Set(types.GetAccountKey(chainID, address), bz)
+}
+
+// GetAccountCoins returns the coins allocated to an account in the genesis
+func (k Keeper) IsAccountSet(ctx sdk.Context, chainID string, address sdk.AccAddress) bool {
+	store := ctx.KVStore(k.storeKey)
+	return store.Has(types.GetAccountKey(chainID, address))
 }
 
 // IsAccountSet check if a specific account is set for a specific chain

--- a/x/genesis/keeper/account.go
+++ b/x/genesis/keeper/account.go
@@ -7,7 +7,7 @@ import (
 
 // SetAccount set an account address that exists in the genesis of a chain
 // This allows us to retrieve in a constant time the current accounts of a genesis to perform verifications
-func (k Keeper) SetAccount(ctx sdk.Context, chainID string, address sdk.AccAddress, payload *types.ProposalAddValidatorPayload) {
+func (k Keeper) SetAccount(ctx sdk.Context, chainID string, address sdk.AccAddress, payload *types.ProposalAddAccountPayload) {
 	store := ctx.KVStore(k.storeKey)
 
 	bz := k.cdc.MustMarshalBinaryBare(payload)
@@ -15,9 +15,17 @@ func (k Keeper) SetAccount(ctx sdk.Context, chainID string, address sdk.AccAddre
 }
 
 // GetAccountCoins returns the coins allocated to an account in the genesis
-func (k Keeper) IsAccountSet(ctx sdk.Context, chainID string, address sdk.AccAddress) bool {
+func (k Keeper) GetAccountCoins(ctx sdk.Context, chainID string, address sdk.AccAddress) (sdk.Coins, bool) {
 	store := ctx.KVStore(k.storeKey)
-	return store.Has(types.GetAccountKey(chainID, address))
+
+	value := store.Get(types.GetAccountKey(chainID, address))
+	if value == nil {
+		return nil, false
+	}
+	var payload types.ProposalAddAccountPayload
+	k.cdc.MustUnmarshalBinaryBare(value, &payload)
+
+	return payload.Coins, true
 }
 
 // IsAccountSet check if a specific account is set for a specific chain

--- a/x/genesis/keeper/account_test.go
+++ b/x/genesis/keeper/account_test.go
@@ -10,15 +10,21 @@ func TestSetAccount(t *testing.T) {
 	ctx, k := spnmocks.MockGenesisContext()
 	chainID := spnmocks.MockRandomAlphaString(5)
 	address := spnmocks.MockAccAddress()
+	payload := spnmocks.MockProposalAddAccountPayload()
 
 	// IsAccountSet returns false for not set account
 	isSet := k.IsAccountSet(ctx, chainID, address)
 	require.False(t, isSet)
+	_, found := k.GetAccountCoins(ctx, chainID, address)
+	require.False(t, found)
 
 	// SetAccount set the account
-	k.SetAccount(ctx, chainID, address)
+	k.SetAccount(ctx, chainID, address, payload)
 	isSet = k.IsAccountSet(ctx, chainID, address)
 	require.True(t, isSet)
+	coins, found := k.GetAccountCoins(ctx, chainID, address)
+	require.True(t, found)
+	require.True(t, payload.Coins.IsEqual(coins))
 
 	// The account is not set for a different chain
 	isSet = k.IsAccountSet(ctx, spnmocks.MockRandomAlphaString(6), address)


### PR DESCRIPTION
For approving a validator: verify that the associated account has enough funds for the self-delegation. If not, deny the approval for the add validator proposal