### PR TITLE
fix: remove genesis param from NewMsgChainCreate

### DIFF
--- a/x/genesis/client/cli/tx.go
+++ b/x/genesis/client/cli/tx.go
@@ -5,14 +5,11 @@ import (
 	"io/ioutil"
 	"strconv"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
-	tmjson "github.com/tendermint/tendermint/libs/json"
-	tmtypes "github.com/tendermint/tendermint/types"
-
-	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/tendermint/spn/x/genesis/types"
 )
 
@@ -40,24 +37,12 @@ func GetTxCmd() *cobra.Command {
 // CmdChainCreate returns the transaction command to create a new chain
 func CmdChainCreate() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create-chain [chain-id] [source-URL] [source-hash] [genesis-file]",
+		Use:   "create-chain [chain-id] [source-URL] [source-hash]",
 		Short: "Create a new chain to launch",
-		Args:  cobra.ExactArgs(4),
+		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 			clientCtx, err := client.ReadTxCommandFlags(clientCtx, cmd.Flags())
-			if err != nil {
-				return err
-			}
-
-			// Read genesis file
-			genesisDoc, err := tmtypes.GenesisDocFromFile(args[3])
-			if err != nil {
-				return err
-			}
-
-			// Convert genesis
-			genesis, err := tmjson.Marshal(*genesisDoc)
 			if err != nil {
 				return err
 			}
@@ -68,7 +53,6 @@ func CmdChainCreate() *cobra.Command {
 				clientCtx.GetFromAddress(),
 				args[1],
 				args[2],
-				genesis,
 			)
 			if err := msg.ValidateBasic(); err != nil {
 				return err

--- a/x/genesis/handler_test.go
+++ b/x/genesis/handler_test.go
@@ -17,7 +17,6 @@ func TestHandleMsgChainCreate(t *testing.T) {
 	creator := spnmocks.MockAccAddress()
 	sourceURL := spnmocks.MockRandomString(20)
 	sourceHash := spnmocks.MockRandomString(20)
-	genesis := spnmocks.MockGenesis()
 
 	// A chain can be create
 	msg := types.NewMsgChainCreate(
@@ -25,7 +24,6 @@ func TestHandleMsgChainCreate(t *testing.T) {
 		creator,
 		sourceURL,
 		sourceHash,
-		genesis,
 	)
 	_, err := h(ctx, msg)
 	require.NoError(t, err)
@@ -42,7 +40,6 @@ func TestHandleMsgChainCreate(t *testing.T) {
 		creator,
 		sourceURL,
 		sourceHash,
-		genesis,
 	)
 	_, err = h(ctx, msg)
 	require.Error(t, err)
@@ -69,7 +66,6 @@ func TestHandleMsgReject(t *testing.T) {
 		coordinator,
 		spnmocks.MockRandomAlphaString(10),
 		spnmocks.MockRandomAlphaString(10),
-		spnmocks.MockGenesis(),
 		)
 	_, err = h(ctx, msgChainCreate)
 	require.NoError(t, err)
@@ -176,7 +172,6 @@ func TestHandleMsgApprove(t *testing.T) {
 		coordinator,
 		spnmocks.MockRandomAlphaString(10),
 		spnmocks.MockRandomAlphaString(10),
-		spnmocks.MockGenesis(),
 	)
 	_, err = h(ctx, msgChainCreate)
 	require.NoError(t, err)

--- a/x/genesis/keeper/gprc_query_test.go
+++ b/x/genesis/keeper/gprc_query_test.go
@@ -29,7 +29,6 @@ func TestListChains(t *testing.T) {
 			spnmocks.MockAccAddress(),
 			sourceURLs[i],
 			spnmocks.MockRandomAlphaString(5),
-			spnmocks.MockGenesis(),
 		)
 		h(ctx, msg)
 	}
@@ -268,7 +267,6 @@ func TestLaunchInformation(t *testing.T) {
 		coordinator,
 		spnmocks.MockRandomAlphaString(10),
 		spnmocks.MockRandomAlphaString(10),
-		spnmocks.MockGenesis(),
 	)
 	h(ctx, msgChainCreate)
 

--- a/x/genesis/types/messages.go
+++ b/x/genesis/types/messages.go
@@ -38,7 +38,6 @@ func NewMsgChainCreate(
 	creator sdk.AccAddress,
 	sourceURL string,
 	sourceHash string,
-	genesis []byte,
 ) *MsgChainCreate {
 	return &MsgChainCreate{
 		ChainID:    chainID,


### PR DESCRIPTION
Omit to remove the `genesis` param in `NewMsgChainCreate` from #79