### PR TITLE
fix(genesis): sort pending proposals from list-proposals query

### DIFF
--- a/x/genesis/keeper/gprc_query_test.go
+++ b/x/genesis/keeper/gprc_query_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"sort"
 
 	"github.com/stretchr/testify/require"
 	spnmocks "github.com/tendermint/spn/internal/testing"
@@ -557,34 +558,43 @@ func TestPendingProposals(t *testing.T) {
 	ctx, k := spnmocks.MockGenesisContext()
 	h := genesis.NewHandler(*k)
 
+	coordinator := spnmocks.MockAccAddress()
+	coordinatorIdentity, _ := k.IdentityKeeper.GetIdentifier(ctx, coordinator)
+
 	// Create a new chain
 	chainID := spnmocks.MockRandomAlphaString(5)
 	chain := spnmocks.MockChain()
+	chain.Creator = coordinatorIdentity
 	chain.ChainID = chainID
 	k.SetChain(ctx, *chain)
 
 	// Create an add account proposal
-	proposal1 := spnmocks.MockProposalAddAccountPayload()
+	payload1 := spnmocks.MockProposalAddAccountPayload()
 	msg := types.NewMsgProposalAddAccount(
 		chainID,
 		spnmocks.MockAccAddress(),
-		proposal1,
+		payload1,
 	)
 	_, err := h(ctx, msg)
 	require.NoError(t, err)
 
 	// Create an add validator proposal
-	proposal2 := spnmocks.MockProposalAddValidatorPayload()
+	payload2 := spnmocks.MockProposalAddValidatorPayload()
 	msg2 := types.NewMsgProposalAddValidator(
 		chainID,
 		spnmocks.MockAccAddress(),
-		proposal2,
+		payload2,
 	)
 	_, err = h(ctx, msg2)
 	require.NoError(t, err)
 
 	// Create other proposal to test pending proposal command
 	for i := 0; i < 8; i++ {
+		msg = types.NewMsgProposalAddAccount(
+			chainID,
+			spnmocks.MockAccAddress(),
+			spnmocks.MockProposalAddAccountPayload(),
+		)
 		_, err := h(ctx, msg)
 		require.NoError(t, err)
 	}
@@ -597,6 +607,29 @@ func TestPendingProposals(t *testing.T) {
 	// PendingProposals fails if the chain doesn't exist
 	_, err = k.PendingProposals(ctx, spnmocks.MockRandomAlphaString(6))
 	require.Error(t, err)
+
+	// Let's approve 2 add accounts proposals inside the pending proposals
+	msgApprove := types.NewMsgApprove(
+		chainID,
+		int32(2),
+		coordinator,
+		)
+	_, err = h(ctx, msgApprove)
+	require.NoError(t, err)
+	msgApprove = types.NewMsgApprove(
+		chainID,
+		int32(3),
+		coordinator,
+	)
+	_, err = h(ctx, msgApprove)
+	require.NoError(t, err)
+
+	// The result of pending proposals should be sorted
+	proposals, err = k.PendingProposals(ctx, chainID)
+	require.NoError(t, err)
+	require.True(t, sort.SliceIsSorted(proposals, func(i, j int) bool {
+		return proposals[i].ProposalInformation.ProposalID < proposals[j].ProposalInformation.ProposalID
+	}))
 }
 
 func TestApprovedProposals(t *testing.T) {

--- a/x/genesis/keeper/grpc_query.go
+++ b/x/genesis/keeper/grpc_query.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tendermint/spn/x/genesis/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"sort"
 )
 
 var _ types.QueryServer = Keeper{}
@@ -237,8 +238,13 @@ func (k Keeper) PendingProposals(
 		return nil, errors.New("chain not found")
 	}
 
-	// Get the pending proposal IDs
 	pendingProposals := k.GetPendingProposals(ctx, chainID)
+
+	// To have less on-chain operations, the pending proposal list is not automatically sorted in the store
+	// We sort the list here so the user can the see pending proposals in the order they have been created
+	sort.Slice(pendingProposals.ProposalIDs, func(i, j int) bool {
+		return pendingProposals.ProposalIDs[i] < pendingProposals.ProposalIDs[j]
+	})
 
 	// Fetch all the proposals
 	var proposals []types.Proposal


### PR DESCRIPTION
Sort the pending proposals so that the user can them in the order they have been created.

Improve the tests of proposals a bit