### PR TITLE
Pi

### DIFF
--- a/.github/workflows/rpi.yml
+++ b/.github/workflows/rpi.yml
@@ -1,0 +1,47 @@
+# This workflow makes a 64 bit Raspberry Pi Arch Linux Image.
+# It does not have the security issues mentioned here: https://github.com/tendermint/tendermint/blob/master/docs/tendermint-core/running-in-production.md#validator-signing-on-32-bit-architectures-or-arm
+# Later, more devices will be supported, as well.
+# The "base" is built by: https://github.com/faddat/sos
+# The base image is located at: https://hub.docker.com/r/faddat/spos
+
+name: Rpi
+on: [push, pull_request]
+
+jobs:
+  pi:
+    name: Starport Pi
+    runs-on: ubuntu-latest
+    needs: arm64
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes --credential yes
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Image in Docker
+        run: docker buildx build --tag spn --file .pi/Dockerfile --platform linux/arm64 --cache-from ${{ secrets.DOCKERHUB_USERNAME }}/spn:picache --cache-to ${{ secrets.DOCKERHUB_USERNAME }}/spn:picache --load --progress tty .
+
+      - name: Build Image
+        run: bash .pi/build.sh
+
+      - name: Compress
+        run: xz -T $(nproc) images/starport.img
+
+      - name: Upload image
+        uses: actions/upload-artifact@v2
+        with:
+          name: Starport Pi
+          path: images/starport.img.xz

--- a/.github/workflows/rpi.yml
+++ b/.github/workflows/rpi.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: compile spn
+        run: docker buildx build --tag builder --file .pi/build/Dockerfile --platform linux/arm64 --load --progress tty .
 
       - name: Build Image in Docker
         run: docker buildx build --tag spn --file .pi/Dockerfile --platform linux/arm64 --cache-from ${{ secrets.DOCKERHUB_USERNAME }}/spn:picache --cache-to ${{ secrets.DOCKERHUB_USERNAME }}/spn:picache --load --progress tty .

--- a/.github/workflows/rpi.yml
+++ b/.github/workflows/rpi.yml
@@ -9,9 +9,8 @@ on: [push, pull_request]
 
 jobs:
   pi:
-    name: Starport Pi
+    name: SPN Pi
     runs-on: ubuntu-latest
-    needs: arm64
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/rpi.yml
+++ b/.github/workflows/rpi.yml
@@ -29,9 +29,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
-      - name: compile spn
-        run: docker buildx build --tag builder --file .pi/build/Dockerfile --platform linux/arm64 --load --progress tty .
 
       - name: Build Image in Docker
         run: docker buildx build --tag spn --file .pi/Dockerfile --platform linux/arm64 --cache-from ${{ secrets.DOCKERHUB_USERNAME }}/spn:picache --cache-to ${{ secrets.DOCKERHUB_USERNAME }}/spn:picache --load --progress tty .

--- a/.github/workflows/rpi.yml
+++ b/.github/workflows/rpi.yml
@@ -37,10 +37,10 @@ jobs:
         run: bash .pi/build.sh
 
       - name: Compress
-        run: xz -T $(nproc) images/starport.img
+        run: xz -T $(nproc) images/spn.img
 
       - name: Upload image
         uses: actions/upload-artifact@v2
         with:
           name: Starport Pi
-          path: images/starport.img.xz
+          path: images/spn.img.xz

--- a/.pi/Dockerfile
+++ b/.pi/Dockerfile
@@ -13,6 +13,7 @@ FROM faddat/sos
 # later, update to tendermint/starport
 COPY --from=builder /spn /spn
 
+# Make SPN user, spn hostname so we get spn.local via mdns
 RUN useradd --create-home spn && \
         echo "spn" > /etc/hostname && \
         echo "spn:spn" | chpasswd && \

--- a/.pi/Dockerfile
+++ b/.pi/Dockerfile
@@ -4,7 +4,7 @@ FROM faddat/sos
 RUN pacman -Syyu --noconfirm go && \
         git clone https://github.com/tendermint/spn && \
         cd spn && \
-        go build -mod cmd/spnd -o . && \
+        go build -mod=mod cmd/spnd -o . && \
         mv spnd /usr/bin && \
         pacman -R go go-ipfs
 

--- a/.pi/Dockerfile
+++ b/.pi/Dockerfile
@@ -5,10 +5,11 @@ RUN pacman -Syyu --noconfirm go && \
         git clone https://github.com/tendermint/spn && \
         cd spn && \
         go build -mod=mod -o . ./cmd/spnd && \
-        mv spnd /usr/bin && \
-        pacman -R --noconfirm go && \
-        cd .. && \
-        rm -rf spn
+        mv spnd /usr/bin
+# BEFORE THE CHAIN GOES LIVE, KEEP THE GIT REPO IN THE IMAGE AND KEEP GO TO ALLOW FOR UPDATES
+#        pacman -R --noconfirm go && \
+#        cd .. && \
+#        rm -rf spn
 
 # Make SPN user, spn hostname so we get spn.local via mdns
 RUN useradd --create-home spn && \

--- a/.pi/Dockerfile
+++ b/.pi/Dockerfile
@@ -1,13 +1,3 @@
-FROM tendermintdevelopment/starport AS builder
-
-RUN pacman -S --noconfirm go
-ENV PATH=$PATH:/usr/local/go/bin
-
-COPY . /spn
-WORKDIR /spn
-RUN starport build
-
-
 FROM faddat/sos
 
 # later, update to tendermint/starport
@@ -18,4 +8,3 @@ RUN useradd --create-home spn && \
         echo "spn" > /etc/hostname && \
         echo "spn:spn" | chpasswd && \
         usermod --append --groups wheel spn
-

--- a/.pi/Dockerfile
+++ b/.pi/Dockerfile
@@ -6,7 +6,7 @@ RUN pacman -Syyu --noconfirm go && \
         cd spn && \
         go build -mod=mod -o . ./cmd/spnd && \
         mv spnd /usr/bin && \
-        pacman -R go && \
+        pacman -R --noconfirm go && \
         cd .. && \
         rm -rf spn
 

--- a/.pi/Dockerfile
+++ b/.pi/Dockerfile
@@ -1,0 +1,20 @@
+FROM tendermintdevelopment/starport AS builder
+
+RUN pacman -S --noconfirm go
+ENV PATH=$PATH:/usr/local/go/bin
+
+COPY . /spn
+WORKDIR /spn
+RUN starport build
+
+
+FROM faddat/sos
+
+# later, update to tendermint/starport
+COPY --from=builder /spn /spn
+
+RUN useradd --create-home spn && \
+        echo "spn" > /etc/hostname && \
+        echo "spn:spn" | chpasswd && \
+        usermod --append --groups wheel example_user 
+

--- a/.pi/Dockerfile
+++ b/.pi/Dockerfile
@@ -6,7 +6,7 @@ RUN pacman -Syyu --noconfirm go && \
         cd spn && \
         go build -mod=mod -o . ./cmd/spnd && \
         mv spnd /usr/bin && \
-        pacman -R go go-ipfs && \
+        pacman -R go && \
         cd .. && \
         rm -rf spn
 

--- a/.pi/Dockerfile
+++ b/.pi/Dockerfile
@@ -1,10 +1,17 @@
 FROM faddat/sos
 
-# later, update to tendermint/starport
-COPY --from=builder /spn /spn
+# fetch spn.  Might want to use copy later, but this should only build with changes to master.
+RUN pacman -Syyu --noconfirm go && \
+        git clone https://github.com/tendermint/spn && \
+        cd spn && \
+        go build -mod cmd/spnd -o . && \
+        mv spnd /usr/bin && \
+        pacman -R go go-ipfs
 
 # Make SPN user, spn hostname so we get spn.local via mdns
 RUN useradd --create-home spn && \
         echo "spn" > /etc/hostname && \
         echo "spn:spn" | chpasswd && \
         usermod --append --groups wheel spn
+        
+

--- a/.pi/Dockerfile
+++ b/.pi/Dockerfile
@@ -16,5 +16,5 @@ COPY --from=builder /spn /spn
 RUN useradd --create-home spn && \
         echo "spn" > /etc/hostname && \
         echo "spn:spn" | chpasswd && \
-        usermod --append --groups wheel example_user 
+        usermod --append --groups wheel spn
 

--- a/.pi/Dockerfile
+++ b/.pi/Dockerfile
@@ -4,9 +4,11 @@ FROM faddat/sos
 RUN pacman -Syyu --noconfirm go && \
         git clone https://github.com/tendermint/spn && \
         cd spn && \
-        go build -mod=mod cmd/spnd -o . && \
+        go build -mod=mod -o . ./cmd/spnd && \
         mv spnd /usr/bin && \
-        pacman -R go go-ipfs
+        pacman -R go go-ipfs && \
+        cd .. && \
+        rm -rf spn
 
 # Make SPN user, spn hostname so we get spn.local via mdns
 RUN useradd --create-home spn && \

--- a/.pi/build.sh
+++ b/.pi/build.sh
@@ -43,13 +43,6 @@ rm ./.tmp/result-rootfs.tar
 # ===================================================================================
 
 
-# Unmount anything on the loop device
-sudo umount /dev/loop0p2 || true
-sudo umount /dev/loop0p1 || true
-
-# Detach from the loop device
-sudo losetup -d /dev/loop0 || true
-
 # Create a folder for images
 rm -rf images || true
 mkdir -p images
@@ -58,16 +51,16 @@ mkdir -p images
 fallocate -l 4G "images/spn.img"
 
 # loop-mount the image file so it becomes a disk
-sudo losetup --find --show images/sp.img
+export LOOP=$(sudo losetup --find --show images/spn.img)
 
 # partition the loop-mounted disk
-sudo parted --script /dev/loop0 mklabel msdos
-sudo parted --script /dev/loop0 mkpart primary fat32 0% 200M
-sudo parted --script /dev/loop0 mkpart primary ext4 200M 100%
+sudo parted --script $LOOP mklabel msdos
+sudo parted --script $LOOP mkpart primary fat32 0% 200M
+sudo parted --script $LOOP mkpart primary ext4 200M 100%
 
 # format the newly partitioned loop-mounted disk
-sudo mkfs.vfat -F32 /dev/loop0p1
-sudo mkfs.ext4 -F /dev/loop0p2
+sudo mkfs.vfat -F32 $(echo $LOOP)p1
+sudo mkfs.ext4 -F $(echo $LOOP)p2
 
 # Use the toolbox to copy the rootfs into the filesystem we formatted above.
 # * mount the disk's /boot and / partitions
@@ -76,12 +69,19 @@ sudo mkfs.ext4 -F /dev/loop0p2
 # soon will not use toolbox
 
 sudo mkdir -p mnt/boot mnt/rootfs
-sudo mount /dev/loop0p1 mnt/boot
-sudo mount /dev/loop0p2 mnt/rootfs
+sudo mount $(echo $LOOP)p1 mnt/boot
+sudo mount $(echo $LOOP)p2 mnt/rootfs
 sudo rsync -a ./.tmp/result-rootfs/boot/* mnt/boot
 sudo rsync -a ./.tmp/result-rootfs/* mnt/rootfs --exclude boot
 sudo mkdir mnt/rootfs/boot
 sudo umount mnt/boot mnt/rootfs
 
+# Tell pi where its memory card is:  This is needed only with the mainline linux kernel provied by linux-aarch64
+# sed -i 's/mmcblk0/mmcblk1/g' ./.tmp/result-rootfs/etc/fstab
+
 # Drop the loop mount
-sudo losetup -d /dev/loop0
+sudo losetup -d $LOOP
+
+# Delete .tmp and mnt
+sudo rm -rf ./.tmp
+sudo rm -rf mnt

--- a/.pi/build.sh
+++ b/.pi/build.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# =======================================================================
+# Starport Development Environment Build System
+# =======================================================================
+
+
+# This process uses tools and a design pattern first developed by the pikvm team for their pi-builder and os tools.
+# the biggest differences between this process and theirs are:
+# * we use docker buildx so we don't need to deal with qemu directly.
+# * we are not offering as many choices to users and are designing around automation.
+# Later we can make this work for more devices and platforms with nearly the same technique.
+# Reasonable build targets include: https://archlinuxarm.org/platforms/armv8
+# For example, the Odroid-N2 is the same software-wise as our Router!
+
+# Fail on error
+set -exo pipefail
+
+# Print each command
+set -o xtrace
+
+# EXTRACT IMAGE
+# Make a temporary directory
+rm -rf .tmp || true
+mkdir .tmp
+
+# UNCOMMENT and add username WHEN NOT USING GITHUB ACTIONS
+# docker buildx build --tag starport --file .pi/Dockerfile --platform linux/arm64 --cache-from starport:cache --cache-to starport:cache --load --progress tty .
+
+# save the image to result-rootfs.tar
+docker save --output ./.tmp/result-rootfs.tar spn
+
+# Extract the image using docker-extract
+docker run --rm --tty --volume $(pwd)/./.tmp:/root/./.tmp --workdir /root/./.tmp/.. faddat/toolbox /tools/docker-extract --root ./.tmp/result-rootfs  ./.tmp/result-rootfs.tar
+
+# get rid of result-rootfs.tar to save space
+rm ./.tmp/result-rootfs.tar
+
+
+# ===================================================================================
+# IMAGE: Make a .img file and compress it.
+# Uses Techniques from Disconnected Systems:
+# https://disconnected.systems/blog/raspberry-pi-archlinuxarm-setup/
+# ===================================================================================
+
+
+# Unmount anything on the loop device
+sudo umount /dev/loop0p2 || true
+sudo umount /dev/loop0p1 || true
+
+# Detach from the loop device
+sudo losetup -d /dev/loop0 || true
+
+# Create a folder for images
+rm -rf images || true
+mkdir -p images
+
+# Make the image file
+fallocate -l 4G "images/spn.img"
+
+# loop-mount the image file so it becomes a disk
+sudo losetup --find --show images/sp.img
+
+# partition the loop-mounted disk
+sudo parted --script /dev/loop0 mklabel msdos
+sudo parted --script /dev/loop0 mkpart primary fat32 0% 200M
+sudo parted --script /dev/loop0 mkpart primary ext4 200M 100%
+
+# format the newly partitioned loop-mounted disk
+sudo mkfs.vfat -F32 /dev/loop0p1
+sudo mkfs.ext4 -F /dev/loop0p2
+
+# Use the toolbox to copy the rootfs into the filesystem we formatted above.
+# * mount the disk's /boot and / partitions
+# * use rsync to copy files into the filesystem
+# make a folder so we can mount the boot partition
+# soon will not use toolbox
+
+sudo mkdir -p mnt/boot mnt/rootfs
+sudo mount /dev/loop0p1 mnt/boot
+sudo mount /dev/loop0p2 mnt/rootfs
+sudo rsync -a ./.tmp/result-rootfs/boot/* mnt/boot
+sudo rsync -a ./.tmp/result-rootfs/* mnt/rootfs --exclude boot
+sudo mkdir mnt/rootfs/boot
+sudo umount mnt/boot mnt/rootfs
+
+# Drop the loop mount
+sudo losetup -d /dev/loop0

--- a/.pi/build/Dockerfile
+++ b/.pi/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM tendermintdevelopment/starport
+FROM tendermintdevelopment/starport:arm64
 
 RUN pacman -S --noconfirm go
 ENV PATH=$PATH:/usr/local/go/bin

--- a/.pi/build/Dockerfile
+++ b/.pi/build/Dockerfile
@@ -1,8 +1,0 @@
-FROM tendermintdevelopment/starport:arm64
-
-RUN pacman -S --noconfirm go
-ENV PATH=$PATH:/usr/local/go/bin
-
-COPY . /spn
-WORKDIR /spn
-RUN starport build

--- a/.pi/build/Dockerfile
+++ b/.pi/build/Dockerfile
@@ -1,0 +1,8 @@
+FROM tendermintdevelopment/starport
+
+RUN pacman -S --noconfirm go
+ENV PATH=$PATH:/usr/local/go/bin
+
+COPY . /spn
+WORKDIR /spn
+RUN starport build


### PR DESCRIPTION
This adds Rpi image generation to spn.

In the future, we may wish to consider building distroless images, and running them in Docker on SOS.  Will add to https://github.com/tendermint/starport/issues/401 for discussion.

Also worthy of discussion:

starport now reliably builds and runs starport derived chains.  Perhaps it's all we need?