### PR TITLE
Revert "feat: enable faucet deployment"

### DIFF
--- a/.ansible/playbook.yml
+++ b/.ansible/playbook.yml
@@ -48,3 +48,16 @@
     generate_faucet_account: 100000000000000000000token
   roles:
     - cosmos-node
+
+- hosts: sentries
+  become: yes
+  remote_user: ubuntu
+  vars:
+    app_name: spn
+    faucet_version: stargate
+    cli_name: spnd
+    credit_amount: 100
+    max_credit: 10000
+    denom: token
+  roles:
+    - cosmos-faucet

--- a/config.yml
+++ b/config.yml
@@ -8,7 +8,6 @@ validator:
   name: user1
   staked: "100000000stake"
 faucet:
-  port: 8000
   name: user1
   coins:
     - "1000token"


### PR DESCRIPTION
Still need to have the old faucet so `starport network` can work.