### PR TITLE
Revert "fix(ansible/faucet): use keyring backend test"

### DIFF
--- a/.ansible/roles/cosmos-faucet/defaults/main.yml
+++ b/.ansible/roles/cosmos-faucet/defaults/main.yml
@@ -6,4 +6,3 @@ credit_amount: 10000000
 max_credit: 100000000
 denom: uatom
 faucet_mnemonic: ""
-keyring_backend: "test"

--- a/.ansible/roles/cosmos-faucet/templates/faucet.service.j2
+++ b/.ansible/roles/cosmos-faucet/templates/faucet.service.j2
@@ -19,7 +19,6 @@ Environment=LOG_LEVEL="{{ log_level }}"
 Environment=KEY_NAME={{ key_name }}
 Environment=MNEMONIC="{{ faucet_mnemonic }}"
 Environment=KEYRING_PASSWORD={{ key_password }}
-Environment=KEYRING_BACKEND={{ keyring_backend }}
 Environment=CLI_NAME={{ cli_name }}
 Environment=CREDIT_AMOUNT={{ credit_amount }}
 Environment=MAX_CREDIT={{ max_credit }}


### PR DESCRIPTION
Reverts tendermint/spn#109

Trig deployment with `keyring-password` enabled.