### PR TITLE
fix: address linter issues and enable github action with linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,17 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 6
     steps:
-      - uses: actions/checkout@v2
-      - uses: technote-space/get-diff-action@v1
+      - name: Set up Go
+        uses: actions/setup-go@v2
         with:
-          SUFFIX_FILTER: |
-            .go
-            .mod
-            .sum
+          go-version: 1.16
+      - uses: actions/checkout@v2
+      - uses: technote-space/get-diff-action@v4
+        with:
+          PATTERNS: |
+            **/**.go
+            go.mod
+            go.sum
       - uses: golangci/golangci-lint-action@master
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.27
+          version: v1.37
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
-        if: "env.GIT_DIFF != ''"
+        if: env.GIT_DIFF

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,11 @@ name: Lint
 # This workflow is run on every pull request and push to master
 # The `golangci` will pass without running if no *.{go, mod, sum} files have been changed.
 on:
-  # pull_request:
+  pull_request:
   push:
     branches:
       - master
+      - develop
 jobs:
   golangci:
     name: golangci-lint

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,7 +1,5 @@
 name: Test-Unit
 # run unit tests for Starport Network.
-
-
 on:
   pull_request:
   push:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 run:
   tests: false
 #   # timeout for analysis, e.g. 30s, 5m, default is 1m
-#   timeout: 5m
+  timeout: 5m
 
 linters:
   disable-all: true
@@ -10,7 +10,7 @@ linters:
     - deadcode
     - depguard
     - dogsled
-    # - errcheck
+    - errcheck
     - goconst
     - gocritic
     - gofmt
@@ -20,12 +20,12 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
-    - maligned
+    # - interfacer
+    # - maligned
     - misspell
     - nakedret
     - prealloc
-    - scopelint
+    # - scopelint
     - staticcheck
     - structcheck
     - stylecheck
@@ -38,5 +38,7 @@ linters:
     - nolintlint
 
 issues:
+  exclude:
+    - G404
   max-issues-per-linter: 10000
   max-same-issues: 10000

--- a/internal/parseint/parse.go
+++ b/internal/parseint/parse.go
@@ -1,4 +1,4 @@
-package utils
+package parseint
 
 import "strconv"
 

--- a/internal/parseint/parse_test.go
+++ b/internal/parseint/parse_test.go
@@ -1,7 +1,6 @@
-package utils
+package parseint
 
 import (
-	"fmt"
 	"math"
 	"strconv"
 	"testing"
@@ -14,7 +13,7 @@ func TestParseInt32(t *testing.T) {
 		description string
 		input       string
 		result      int32
-		err         string
+		err         error
 	}{
 		{
 			description: "regular",
@@ -24,12 +23,12 @@ func TestParseInt32(t *testing.T) {
 		{
 			description: "overflow",
 			input:       strconv.Itoa(math.MaxInt64),
-			err:         "strconv.ParseInt: parsing \"%s\": value out of range",
+			err:         strconv.ErrRange,
 		},
 		{
 			description: "not-integer",
 			input:       "teepot",
-			err:         "strconv.ParseInt: parsing \"%s\": invalid syntax",
+			err:         strconv.ErrSyntax,
 		},
 	} {
 		tc := tc
@@ -37,8 +36,8 @@ func TestParseInt32(t *testing.T) {
 			t.Parallel()
 			rst, err := ParseInt32(tc.input)
 			if err != nil {
-				if tc.err != "" {
-					require.EqualError(t, err, fmt.Sprintf(tc.err, tc.input))
+				if tc.err != nil {
+					require.ErrorIs(t, err, tc.err)
 				} else {
 					require.NoError(t, err)
 				}

--- a/internal/testing/mock_genesis.go
+++ b/internal/testing/mock_genesis.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -28,7 +29,7 @@ import (
 	"time"
 )
 
-// MockCodec mocks a codec for the app that contains the necessary types for proto enconding
+// MockCodec mocks a codec for the app that contains the necessary types for proto encoding
 func MockCodec() codec.Marshaler {
 	interfaceRegistry := codectypes.NewInterfaceRegistry()
 
@@ -68,7 +69,9 @@ func MockGenesisContext() (sdk.Context, *keeper.Keeper) {
 
 	// Mount stores
 	cms.MountStoreWithDB(keys[types.StoreKey], sdk.StoreTypeIAVL, db)
-	cms.LoadLatestVersion()
+	if err := cms.LoadLatestVersion(); err != nil {
+		panic(err.Error())
+	}
 
 	// Create context
 	ctx := sdk.NewContext(cms, tmproto.Header{}, false, log.NewNopLogger())
@@ -144,12 +147,12 @@ func MockProposal() *types.Proposal {
 func MockProposalList() *types.ProposalList {
 	return &types.ProposalList{
 		ProposalIDs: []int32{
-			int32(rand.Intn(10000)),
-			int32(rand.Intn(10000)),
-			int32(rand.Intn(10000)),
-			int32(rand.Intn(10000)),
-			int32(rand.Intn(10000)),
-			int32(rand.Intn(10000)),
+			rand.Int31n(10000),
+			rand.Int31n(10000),
+			rand.Int31n(10000),
+			rand.Int31n(10000),
+			rand.Int31n(10000),
+			rand.Int31n(10000),
 		},
 	}
 }

--- a/internal/testing/mock_identity.go
+++ b/internal/testing/mock_identity.go
@@ -33,7 +33,9 @@ func MockIdentityContext() (sdk.Context, *keeper.Keeper) {
 
 	// Mount stores
 	cms.MountStoreWithDB(keys[types.StoreKey], sdk.StoreTypeIAVL, db)
-	cms.LoadLatestVersion()
+	if err := cms.LoadLatestVersion(); err != nil {
+		panic(err.Error())
+	}
 
 	// Create context
 	ctx := sdk.NewContext(cms, tmproto.Header{}, false, log.NewNopLogger())

--- a/internal/utils/parse.go
+++ b/internal/utils/parse.go
@@ -1,0 +1,13 @@
+package utils
+
+import "strconv"
+
+// ParseInt32 convert string in base 10 to 32 bit signed integer.
+// For the details see strconv.ParseInt.
+func ParseInt32(s string) (int32, error) {
+	rst, err := strconv.ParseInt(s, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return int32(rst), nil
+}

--- a/internal/utils/parse_test.go
+++ b/internal/utils/parse_test.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseInt32(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		input       string
+		result      int32
+		err         string
+	}{
+		{
+			description: "regular",
+			input:       "10",
+			result:      10,
+		},
+		{
+			description: "overflow",
+			input:       strconv.Itoa(math.MaxInt64),
+			err:         "strconv.ParseInt: parsing \"%s\": value out of range",
+		},
+		{
+			description: "not-integer",
+			input:       "teepot",
+			err:         "strconv.ParseInt: parsing \"%s\": invalid syntax",
+		},
+	} {
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+			rst, err := ParseInt32(tc.input)
+			if err != nil {
+				if tc.err != "" {
+					require.EqualError(t, err, fmt.Sprintf(tc.err, tc.input))
+				} else {
+					require.NoError(t, err)
+				}
+			}
+			require.Equal(t, tc.result, rst)
+		})
+	}
+}

--- a/x/identity/client/cli/tx.go
+++ b/x/identity/client/cli/tx.go
@@ -40,6 +40,9 @@ func CmdSetUsername() *cobra.Command {
 			}
 
 			msg, err := types.NewMsgSetUsername(clientCtx.GetFromAddress(), args[0])
+			if err != nil {
+				return err
+			}
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/identity/client/rest/rest.go
+++ b/x/identity/client/rest/rest.go
@@ -30,7 +30,7 @@ func registerQueryRoutes(clientCtx client.Context, r *mux.Router) {
 }
 
 func registerTxHandlers(clientCtx client.Context, r *mux.Router) {
-	r.HandleFunc(fmt.Sprintf("/identity/set_username"), setUsernameHandler(clientCtx)).Methods(MethodPost)
+	r.HandleFunc("/identity/set_username", setUsernameHandler(clientCtx)).Methods(MethodPost)
 }
 
 func usernameHandler(clientCtx client.Context) http.HandlerFunc {

--- a/x/launch/client/cli/query.go
+++ b/x/launch/client/cli/query.go
@@ -3,12 +3,12 @@ package cli
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
+	"github.com/tendermint/spn/internal/utils"
 	"github.com/tendermint/spn/x/launch/types"
 )
 
@@ -139,14 +139,14 @@ func CmdShowProposal() *cobra.Command {
 			queryClient := types.NewQueryClient(clientCtx)
 
 			// Convert proposal ID
-			proposalID, err := strconv.Atoi(args[1])
+			proposalID, err := utils.ParseInt32(args[1])
 			if err != nil {
 				return err
 			}
 
 			params := &types.QueryShowProposalRequest{
 				ChainID:    args[0],
-				ProposalID: int32(proposalID),
+				ProposalID: proposalID,
 			}
 
 			res, err := queryClient.ShowProposal(context.Background(), params)
@@ -236,12 +236,12 @@ func CmdSimulatedLaunchInformation() *cobra.Command {
 			proposalIDsArg := strings.Split(args[1], ",")
 			for _, proposalIDArg := range proposalIDsArg {
 				// Convert proposal ID
-				proposalID, err := strconv.Atoi(proposalIDArg)
+				proposalID, err := utils.ParseInt32(proposalIDArg)
 				if err != nil {
 					return err
 				}
 
-				proposalIDs = append(proposalIDs, int32(proposalID))
+				proposalIDs = append(proposalIDs, proposalID)
 			}
 
 			params := &types.QuerySimulatedLaunchInformationRequest{

--- a/x/launch/client/cli/query.go
+++ b/x/launch/client/cli/query.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
-	"github.com/tendermint/spn/internal/utils"
+	"github.com/tendermint/spn/internal/parseint"
 	"github.com/tendermint/spn/x/launch/types"
 )
 
@@ -139,7 +139,7 @@ func CmdShowProposal() *cobra.Command {
 			queryClient := types.NewQueryClient(clientCtx)
 
 			// Convert proposal ID
-			proposalID, err := utils.ParseInt32(args[1])
+			proposalID, err := parseint.ParseInt32(args[1])
 			if err != nil {
 				return err
 			}
@@ -236,7 +236,7 @@ func CmdSimulatedLaunchInformation() *cobra.Command {
 			proposalIDsArg := strings.Split(args[1], ",")
 			for _, proposalIDArg := range proposalIDsArg {
 				// Convert proposal ID
-				proposalID, err := utils.ParseInt32(proposalIDArg)
+				proposalID, err := parseint.ParseInt32(proposalIDArg)
 				if err != nil {
 					return err
 				}

--- a/x/launch/client/cli/tx.go
+++ b/x/launch/client/cli/tx.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
+	"github.com/tendermint/spn/internal/utils"
 	"github.com/tendermint/spn/x/launch/types"
 )
 
@@ -111,7 +111,7 @@ func CmdApprove() *cobra.Command {
 			}
 
 			// Convert value for proposal ID
-			proposalID, err := strconv.Atoi(args[1])
+			proposalID, err := utils.ParseInt32(args[1])
 			if err != nil {
 				return err
 			}
@@ -119,7 +119,7 @@ func CmdApprove() *cobra.Command {
 			// Create and send message
 			msg := types.NewMsgApprove(
 				args[0],
-				int32(proposalID),
+				proposalID,
 				clientCtx.GetFromAddress().String(),
 			)
 			if err := msg.ValidateBasic(); err != nil {
@@ -147,7 +147,7 @@ func CmdReject() *cobra.Command {
 			}
 
 			// Convert value for proposal ID
-			proposalID, err := strconv.Atoi(args[1])
+			proposalID, err := utils.ParseInt32(args[1])
 			if err != nil {
 				return err
 			}
@@ -155,7 +155,7 @@ func CmdReject() *cobra.Command {
 			// Create and send message
 			msg := types.NewMsgReject(
 				args[0],
-				int32(proposalID),
+				proposalID,
 				clientCtx.GetFromAddress().String(),
 			)
 			if err := msg.ValidateBasic(); err != nil {

--- a/x/launch/client/cli/tx.go
+++ b/x/launch/client/cli/tx.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
-	"github.com/tendermint/spn/internal/utils"
+	"github.com/tendermint/spn/internal/parseint"
 	"github.com/tendermint/spn/x/launch/types"
 )
 
@@ -111,7 +111,7 @@ func CmdApprove() *cobra.Command {
 			}
 
 			// Convert value for proposal ID
-			proposalID, err := utils.ParseInt32(args[1])
+			proposalID, err := parseint.ParseInt32(args[1])
 			if err != nil {
 				return err
 			}
@@ -147,7 +147,7 @@ func CmdReject() *cobra.Command {
 			}
 
 			// Convert value for proposal ID
-			proposalID, err := utils.ParseInt32(args[1])
+			proposalID, err := parseint.ParseInt32(args[1])
 			if err != nil {
 				return err
 			}

--- a/x/launch/keeper/approval.go
+++ b/x/launch/keeper/approval.go
@@ -2,16 +2,19 @@ package keeper
 
 import (
 	"errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/spn/x/launch/types"
 )
+
+var errChainDoesntExist = errors.New("chain doesn't exist")
 
 // CheckProposalApproval checks if a proposal can be applied to the launch and approved depending on the current state of the launch information
 func (k Keeper) CheckProposalApproval(ctx sdk.Context, chainID string, proposal types.Proposal) error {
 	// Check if chain exists
 	_, found := k.GetChain(ctx, chainID)
 	if !found {
-		return errors.New("Chain doesn't exist")
+		return errChainDoesntExist
 	}
 
 	switch payload := proposal.Payload.(type) {
@@ -29,7 +32,7 @@ func (k Keeper) ApplyProposalApproval(ctx sdk.Context, chainID string, proposal 
 	// Check if chain exists
 	_, found := k.GetChain(ctx, chainID)
 	if !found {
-		return errors.New("Chain doesn't exist")
+		return errChainDoesntExist
 	}
 
 	switch payload := proposal.Payload.(type) {

--- a/x/launch/keeper/grpc_query.go
+++ b/x/launch/keeper/grpc_query.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -11,7 +13,6 @@ import (
 	"github.com/tendermint/spn/x/launch/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"sort"
 )
 
 var _ types.QueryServer = Keeper{}
@@ -297,15 +298,13 @@ func (k Keeper) PendingProposals(
 	})
 
 	// Fetch all the proposals
-	var proposals []types.Proposal
+	proposals := make([]types.Proposal, 0, len(pendingProposals.ProposalIDs))
 	for _, pending := range pendingProposals.ProposalIDs {
 		proposal, found := k.GetProposal(ctx, chainID, pending)
-
 		// Every proposals in the pending pool should exist
 		if !found {
 			panic(fmt.Sprintf("The proposal %v doesn't exist", pending))
 		}
-
 		proposals = append(proposals, proposal)
 	}
 
@@ -327,15 +326,13 @@ func (k Keeper) ApprovedProposals(
 	approvedProposals := k.GetApprovedProposals(ctx, chainID)
 
 	// Fetch all the proposals
-	var proposals []types.Proposal
+	proposals := make([]types.Proposal, 0, len(approvedProposals.ProposalIDs))
 	for _, approved := range approvedProposals.ProposalIDs {
 		proposal, found := k.GetProposal(ctx, chainID, approved)
-
 		// Every proposals in the approved pool should exist
 		if !found {
 			panic(fmt.Sprintf("The proposal %v doesn't exist", approved))
 		}
-
 		proposals = append(proposals, proposal)
 	}
 
@@ -357,15 +354,13 @@ func (k Keeper) RejectedProposals(
 	rejectedProposals := k.GetRejectedProposals(ctx, chainID)
 
 	// Fetch all the proposals
-	var proposals []types.Proposal
+	proposals := make([]types.Proposal, 0, len(rejectedProposals.ProposalIDs))
 	for _, rejected := range rejectedProposals.ProposalIDs {
 		proposal, found := k.GetProposal(ctx, chainID, rejected)
-
 		// Every proposals in the rejected pool should exist
 		if !found {
 			panic(fmt.Sprintf("The proposal %v doesn't exist", rejected))
 		}
-
 		proposals = append(proposals, proposal)
 	}
 

--- a/x/launch/keeper/querier.go
+++ b/x/launch/keeper/querier.go
@@ -42,7 +42,7 @@ func listChains(ctx sdk.Context, req abci.RequestQuery, keeper Keeper, legacyQue
 	chains := keeper.GetAllChains(ctx, "")
 
 	// Read chainID
-	var chainIDs []string
+	chainIDs := make([]string, 0, len(chains))
 	for _, chain := range chains {
 		chainIDs = append(chainIDs, chain.ChainID)
 	}

--- a/x/launch/types/chain.go
+++ b/x/launch/types/chain.go
@@ -2,9 +2,10 @@ package types
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"time"
 )
 
 // NewChain creates a new chain information object

--- a/x/launch/types/messages.go
+++ b/x/launch/types/messages.go
@@ -1,13 +1,8 @@
 package types
 
 import (
-	"github.com/cosmos/cosmos-sdk/codec"
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
-	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 // Chat message types
@@ -317,16 +312,4 @@ func (msg MsgProposalAddValidator) ValidateBasic() error {
 	}
 
 	return nil
-}
-
-// gentxCodec returns a simple codec marshaler to unpack the message inside gentx
-func gentxCodec() codec.Marshaler {
-	interfaceRegistry := codectypes.NewInterfaceRegistry()
-	staking.RegisterInterfaces(interfaceRegistry)
-	cryptocodec.RegisterInterfaces(interfaceRegistry)
-	authtypes.RegisterInterfaces(interfaceRegistry)
-
-	cdc := codec.NewProtoCodec(interfaceRegistry)
-
-	return cdc
 }

--- a/x/launch/types/proposal.go
+++ b/x/launch/types/proposal.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/tendermint/spn/internal/utils"
+	"github.com/tendermint/spn/internal/parseint"
 )
 
 // NewProposalInformation initializes a new proposal information structure
@@ -91,7 +91,7 @@ func MarshalProposalCount(cdc codec.BinaryMarshaler, count int32) []byte {
 
 // UnmarshalProposalCount decodes proposal count from the store
 func UnmarshalProposalCount(cdc codec.BinaryMarshaler, value []byte) int32 {
-	count, err := utils.ParseInt32(string(value))
+	count, err := parseint.ParseInt32(string(value))
 	if err != nil {
 		// We should never have non numeric data as proposal count
 		panic("The proposal count store contains an invalid value")

--- a/x/launch/types/proposal.go
+++ b/x/launch/types/proposal.go
@@ -2,9 +2,11 @@ package types
 
 import (
 	"errors"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"strconv"
 	"time"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/tendermint/spn/internal/utils"
 )
 
 // NewProposalInformation initializes a new proposal information structure
@@ -83,16 +85,16 @@ func UnmarshalProposalList(cdc codec.BinaryMarshaler, value []byte) ProposalList
 
 // MarshalProposalCount encodes proposal count for the store
 func MarshalProposalCount(cdc codec.BinaryMarshaler, count int32) []byte {
+	// FIXME replace it with binary.LittleEndian.PutInt32
 	return []byte(strconv.Itoa(int(count)))
 }
 
 // UnmarshalProposalCount decodes proposal count from the store
 func UnmarshalProposalCount(cdc codec.BinaryMarshaler, value []byte) int32 {
-	count, err := strconv.Atoi(string(value))
+	count, err := utils.ParseInt32(string(value))
 	if err != nil {
 		// We should never have non numeric data as proposal count
 		panic("The proposal count store contains an invalid value")
 	}
-
-	return int32(count)
+	return count
 }

--- a/x/launch/types/proposal_add_account.go
+++ b/x/launch/types/proposal_add_account.go
@@ -3,6 +3,7 @@ package types
 import (
 	"errors"
 	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )

--- a/x/launch/types/proposal_add_validator.go
+++ b/x/launch/types/proposal_add_validator.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )

--- a/x/launch/types/proposal_change.go
+++ b/x/launch/types/proposal_change.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
@@ -41,7 +42,7 @@ func ValidateProposalPayloadChange(payload *ProposalChangePayload) error {
 		// Path components must contain alphanumeric characters
 		for _, c := range pathComponent {
 			if !isChangePathAuthorizedChar(c) {
-				return errors.New("Invalid change path")
+				return errors.New("invalid change path")
 			}
 		}
 	}


### PR DESCRIPTION
Changes are straightforward and only addressing reported issues.
I disabled `interfacer` linter, as it doesn't always report relevant things,
also disabled rule G404: weak randomness linter, it recommends using crypto.Rand
even when it is unnecessary.

closes: https://github.com/tendermint/spn/issues/119