### PR TITLE
fix(Makefile): remove exclude rules from the lint make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ format:
 ## lint: Run Golang CI Lint.
 lint:
 	@echo Running gocilint...
-	@golangci-lint run --out-format=tab --issues-exit-code=0 -e SA1019 -e unused
+	@golangci-lint run --out-format=tab --issues-exit-code=0
 
 ## test-unit: Run the unit tests.
 test-unit:


### PR DESCRIPTION
### What does this PR does?

remove exclude rules from the lint inside the makefile `lint` command

