### PR TITLE
refactor(launch): restrict chain name to only lowercase character

### DIFF
--- a/x/launch/types/chain.go
+++ b/x/launch/types/chain.go
@@ -9,7 +9,11 @@ import (
 	codec "github.com/cosmos/cosmos-sdk/codec/types"
 )
 
-const chainIDSeparator = "-"
+const (
+	chainIDSeparator = "-"
+	chainNameMaxLength = 30
+)
+
 
 // GetDefaultInitialGenesis returns the DefaultInitialGenesis structure if the initial genesis for the chain is default genesis
 func (c Chain) GetDefaultInitialGenesis(unpacker codec.AnyUnpacker) (*DefaultInitialGenesis, error) {
@@ -61,11 +65,12 @@ func ParseChainID(chainID string) (string, uint64, error) {
 
 // CheckChainName verifies the name is valid as a chain name
 func CheckChainName(chainName string) error {
-	// TODO: Determine final check: https://github.com/tendermint/spn/issues/194
-
-	// No empty
 	if len(chainName) == 0 {
 		return errors.New("chain name can't be empty")
+	}
+
+	if len(chainName) > chainNameMaxLength {
+		return fmt.Errorf("chain name is too big, max length is %v", chainNameMaxLength)
 	}
 
 	// Iterate characters
@@ -80,5 +85,5 @@ func CheckChainName(chainName string) error {
 
 // isChainAuthorizedChar checks to ensure that all letters in the chain name are valid
 func isChainAuthorizedChar(c rune) bool {
-	return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9')
+	return 'a' <= c && c <= 'z'
 }

--- a/x/launch/types/chain.go
+++ b/x/launch/types/chain.go
@@ -10,10 +10,9 @@ import (
 )
 
 const (
-	chainIDSeparator = "-"
+	chainIDSeparator   = "-"
 	chainNameMaxLength = 30
 )
-
 
 // GetDefaultInitialGenesis returns the DefaultInitialGenesis structure if the initial genesis for the chain is default genesis
 func (c Chain) GetDefaultInitialGenesis(unpacker codec.AnyUnpacker) (*DefaultInitialGenesis, error) {

--- a/x/launch/types/chain_test.go
+++ b/x/launch/types/chain_test.go
@@ -75,6 +75,16 @@ func TestParseChainID(t *testing.T) {
 			valid:          true,
 		},
 		{
+			desc:    "Empty",
+			chainID: "",
+			valid:   false,
+		},
+		{
+			desc:    "Too big",
+			chainID: sample.AlphaString(31) + "-1",
+			valid:   false,
+		},
+		{
 			desc:    "No separator",
 			chainID: "foo42",
 			valid:   false,
@@ -102,6 +112,11 @@ func TestParseChainID(t *testing.T) {
 		{
 			desc:    "Invalid chain name",
 			chainID: "foo/bar-42",
+			valid:   false,
+		},
+		{
+			desc:    "Uppercase",
+			chainID: "fooBar-42",
 			valid:   false,
 		},
 	} {


### PR DESCRIPTION
Restrict the chain name to only lowercase character
