### PR TITLE
refactor(tests): Assert only the error type using the `require.ErrorIs` method

### DIFF
--- a/pkg/errors/critical.go
+++ b/pkg/errors/critical.go
@@ -6,9 +6,9 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-const codespace = "critical"
+const codespace = "CRITICAL"
 
-var ErrCritical = sdkerrors.Register(codespace, 0, "CRITICAL: the state of the blockchain is inconsistent or an invariant is broken")
+var ErrCritical = sdkerrors.Register(codespace, 0, "the state of the blockchain is inconsistent or an invariant is broken")
 
 // Critical handles and/or returns an error in case a critical error has been encountered:
 // - Inconsistent state

--- a/pkg/errors/critical.go
+++ b/pkg/errors/critical.go
@@ -6,9 +6,9 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-const codesapace = "critical"
+const codespace = "critical"
 
-var ErrCritical = sdkerrors.Register(codesapace, 0, "CRITICAL: the state of the blockchain is inconsistent or an invariant is broken")
+var ErrCritical = sdkerrors.Register(codespace, 0, "CRITICAL: the state of the blockchain is inconsistent or an invariant is broken")
 
 // Critical handles and/or returns an error in case a critical error has been encountered:
 // - Inconsistent state

--- a/pkg/errors/critical.go
+++ b/pkg/errors/critical.go
@@ -1,13 +1,14 @@
 package errors
 
 import (
-	"errors"
 	"fmt"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-var ErrCritical = errors.New("CRITICAL: the state of the blockchain is inconsistent or an invariant is broken")
+const codesapace = "critical"
+
+var ErrCritical = sdkerrors.Register(codesapace, 0, "CRITICAL: the state of the blockchain is inconsistent or an invariant is broken")
 
 // Critical handles and/or returns an error in case a critical error has been encountered:
 // - Inconsistent state

--- a/x/launch/keeper/msg_server_request_add_account_test.go
+++ b/x/launch/keeper/msg_server_request_add_account_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/spn/testutil/sample"
 	"github.com/tendermint/spn/x/launch/types"
@@ -45,7 +44,7 @@ func TestMsgRequestAddAccount(t *testing.T) {
 				Address: sample.AccAddress(),
 				Coins:   sample.Coins(),
 			},
-			err: sdkerrors.Wrap(types.ErrChainNotFound, invalidChain),
+			err: types.ErrChainNotFound,
 		}, {
 			name: "launch triggered chain",
 			msg: types.MsgRequestAddAccount{
@@ -53,7 +52,7 @@ func TestMsgRequestAddAccount(t *testing.T) {
 				Address: addr1,
 				Coins:   sample.Coins(),
 			},
-			err: sdkerrors.Wrap(types.ErrTriggeredLaunch, chains[3].ChainID),
+			err: types.ErrTriggeredLaunch,
 		}, {
 			name: "coordinator not found",
 			msg: types.MsgRequestAddAccount{
@@ -61,8 +60,7 @@ func TestMsgRequestAddAccount(t *testing.T) {
 				Address: addr1,
 				Coins:   sample.Coins(),
 			},
-			err: sdkerrors.Wrapf(types.ErrChainInactive,
-				"the chain %s coordinator has been deleted", chains[4].ChainID),
+			err: types.ErrChainInactive,
 		}, {
 			name: "add chain 1 request 1",
 			msg: types.MsgRequestAddAccount{
@@ -125,8 +123,7 @@ func TestMsgRequestAddAccount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := srv.RequestAddAccount(ctx, &tt.msg)
 			if tt.err != nil {
-				require.Error(t, err)
-				require.Equal(t, tt.err.Error(), err.Error())
+				require.ErrorIs(t, tt.err, err)
 				return
 			}
 			require.NoError(t, err)

--- a/x/launch/keeper/msg_server_request_add_vested_account_test.go
+++ b/x/launch/keeper/msg_server_request_add_vested_account_test.go
@@ -52,7 +52,7 @@ func TestMsgRequestAddVestedAccount(t *testing.T) {
 				StartingBalance: sample.Coins(),
 				Options:         delayedVesting,
 			},
-			err: sdkerrors.Wrap(types.ErrChainNotFound, invalidChain),
+			err: types.ErrChainNotFound,
 		}, {
 			name: "launch triggered chain",
 			msg: types.MsgRequestAddVestedAccount{
@@ -61,7 +61,7 @@ func TestMsgRequestAddVestedAccount(t *testing.T) {
 				StartingBalance: sample.Coins(),
 				Options:         delayedVesting,
 			},
-			err: sdkerrors.Wrap(types.ErrTriggeredLaunch, chains[3].ChainID),
+			err: types.ErrTriggeredLaunch,
 		}, {
 			name: "coordinator not found",
 			msg: types.MsgRequestAddVestedAccount{
@@ -141,8 +141,7 @@ func TestMsgRequestAddVestedAccount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := srv.RequestAddVestedAccount(ctx, &tt.msg)
 			if tt.err != nil {
-				require.Error(t, err)
-				require.Equal(t, tt.err.Error(), err.Error())
+				require.ErrorIs(t, tt.err, err)
 				return
 			}
 			require.NoError(t, err)

--- a/x/launch/keeper/msg_server_request_remove_account_test.go
+++ b/x/launch/keeper/msg_server_request_remove_account_test.go
@@ -49,7 +49,7 @@ func TestMsgRequestRemoveAccount(t *testing.T) {
 				Creator: addr1,
 				Address: addr1,
 			},
-			err: sdkerrors.Wrap(types.ErrChainNotFound, invalidChain),
+			err: types.ErrChainNotFound,
 		}, {
 			name: "launch triggered chain",
 			msg: types.MsgRequestRemoveAccount{
@@ -57,7 +57,7 @@ func TestMsgRequestRemoveAccount(t *testing.T) {
 				Creator: addr1,
 				Address: addr1,
 			},
-			err: sdkerrors.Wrap(types.ErrTriggeredLaunch, chains[3].ChainID),
+			err: types.ErrTriggeredLaunch,
 		}, {
 			name: "coordinator not found",
 			msg: types.MsgRequestRemoveAccount{
@@ -74,7 +74,7 @@ func TestMsgRequestRemoveAccount(t *testing.T) {
 				Creator: addr1,
 				Address: addr3,
 			},
-			err: sdkerrors.Wrap(types.ErrNoAddressPermission, addr1),
+			err: types.ErrNoAddressPermission,
 		}, {
 			name: "add chain 1 request 1",
 			msg: types.MsgRequestRemoveAccount{
@@ -137,8 +137,7 @@ func TestMsgRequestRemoveAccount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := srv.RequestRemoveAccount(ctx, &tt.msg)
 			if tt.err != nil {
-				require.Error(t, err)
-				require.Equal(t, tt.err.Error(), err.Error())
+				require.ErrorIs(t, tt.err, err)
 				return
 			}
 			require.NoError(t, err)

--- a/x/launch/keeper/msg_server_request_remove_validator_test.go
+++ b/x/launch/keeper/msg_server_request_remove_validator_test.go
@@ -49,7 +49,7 @@ func TestMsgRequestRemoveValidator(t *testing.T) {
 				Creator:          addr1,
 				ValidatorAddress: addr1,
 			},
-			err: sdkerrors.Wrap(types.ErrChainNotFound, invalidChain),
+			err: types.ErrChainNotFound,
 		}, {
 			name: "launch triggered chain",
 			msg: types.MsgRequestRemoveValidator{
@@ -57,7 +57,7 @@ func TestMsgRequestRemoveValidator(t *testing.T) {
 				Creator:          addr1,
 				ValidatorAddress: addr1,
 			},
-			err: sdkerrors.Wrap(types.ErrTriggeredLaunch, chains[3].ChainID),
+			err: types.ErrTriggeredLaunch,
 		}, {
 			name: "coordinator not found",
 			msg: types.MsgRequestRemoveValidator{
@@ -74,7 +74,7 @@ func TestMsgRequestRemoveValidator(t *testing.T) {
 				Creator:          addr1,
 				ValidatorAddress: addr3,
 			},
-			err: sdkerrors.Wrap(types.ErrNoAddressPermission, addr1),
+			err: types.ErrNoAddressPermission,
 		}, {
 			name: "add chain 1 request 1",
 			msg: types.MsgRequestRemoveValidator{
@@ -137,8 +137,7 @@ func TestMsgRequestRemoveValidator(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := srv.RequestRemoveValidator(ctx, &tt.msg)
 			if tt.err != nil {
-				require.Error(t, err)
-				require.Equal(t, tt.err.Error(), err.Error())
+				require.ErrorIs(t, tt.err, err)
 				return
 			}
 			require.NoError(t, err)

--- a/x/launch/keeper/msg_server_settle_request_test.go
+++ b/x/launch/keeper/msg_server_settle_request_test.go
@@ -61,7 +61,7 @@ func TestMsgSettleRequest(t *testing.T) {
 				RequestID:   requests[0].RequestID,
 				Approve:     true,
 			},
-			err: sdkerrors.Wrap(types.ErrChainNotFound, invalidChain),
+			err: types.ErrChainNotFound,
 		}, {
 			name: "launch triggered chain",
 			msg: types.MsgSettleRequest{
@@ -70,7 +70,7 @@ func TestMsgSettleRequest(t *testing.T) {
 				RequestID:   requests[0].RequestID,
 				Approve:     true,
 			},
-			err: sdkerrors.Wrap(types.ErrTriggeredLaunch, chains[0].ChainID),
+			err: types.ErrTriggeredLaunch,
 		}, {
 			name: "coordinator not found",
 			msg: types.MsgSettleRequest{
@@ -89,7 +89,7 @@ func TestMsgSettleRequest(t *testing.T) {
 				RequestID:   requests[0].RequestID,
 				Approve:     true,
 			},
-			err: sdkerrors.Wrap(types.ErrNoAddressPermission, coordinator2.Address),
+			err: types.ErrNoAddressPermission,
 		}, {
 			name: "approve an invalid request",
 			msg: types.MsgSettleRequest{
@@ -161,8 +161,7 @@ func TestMsgSettleRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := srv.SettleRequest(ctx, &tt.msg)
 			if tt.err != nil {
-				require.Error(t, err)
-				require.Equal(t, tt.err.Error(), err.Error())
+				require.ErrorIs(t, tt.err, err)
 				return
 			}
 			require.NoError(t, err)

--- a/x/launch/keeper/request_test.go
+++ b/x/launch/keeper/request_test.go
@@ -160,16 +160,14 @@ func TestApplyRequest(t *testing.T) {
 		}, {
 			name:    "invalid request",
 			request: *sample.RequestWithContent(chainID, invalidContent),
-			err: spnerrors.Critical(
-				"unknown request content type"),
+			err:     spnerrors.ErrCritical,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := applyRequest(sdkCtx, *k, chainID, tt.request)
 			if tt.err != nil {
-				require.Error(t, err)
-				require.Equal(t, tt.err.Error(), err.Error())
+				require.ErrorIs(t, tt.err, err)
 				return
 			}
 			require.NoError(t, err)

--- a/x/launch/types/message_request_add_account_test.go
+++ b/x/launch/types/message_request_add_account_test.go
@@ -25,8 +25,7 @@ func TestMsgRequestAddAccount_ValidateBasic(t *testing.T) {
 				ChainID: chainID,
 				Coins:   sample.Coins(),
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "invalid chain id",
 			msg: types.MsgRequestAddAccount{
@@ -34,7 +33,7 @@ func TestMsgRequestAddAccount_ValidateBasic(t *testing.T) {
 				ChainID: "invalid_chain",
 				Coins:   sample.Coins(),
 			},
-			err: sdkerrors.Wrap(types.ErrInvalidChainID, "invalid_chain"),
+			err: types.ErrInvalidChainID,
 		}, {
 			name: "message without coins",
 			msg: types.MsgRequestAddAccount{
@@ -42,7 +41,7 @@ func TestMsgRequestAddAccount_ValidateBasic(t *testing.T) {
 				ChainID: chainID,
 				Coins:   sdk.NewCoins(),
 			},
-			err: sdkerrors.Wrap(types.ErrInvalidCoins, addr),
+			err: types.ErrInvalidCoins,
 		}, {
 			name: "message with invalid coins",
 			msg: types.MsgRequestAddAccount{
@@ -50,7 +49,7 @@ func TestMsgRequestAddAccount_ValidateBasic(t *testing.T) {
 				ChainID: chainID,
 				Coins:   sdk.Coins{sdk.Coin{Denom: "", Amount: sdk.NewInt(10)}},
 			},
-			err: sdkerrors.Wrap(types.ErrInvalidCoins, addr),
+			err: types.ErrInvalidCoins,
 		}, {
 			name: "valid message",
 			msg: types.MsgRequestAddAccount{

--- a/x/launch/types/message_request_add_vested_account_test.go
+++ b/x/launch/types/message_request_add_vested_account_test.go
@@ -40,8 +40,7 @@ func TestMsgRequestAddVestedAccount_ValidateBasic(t *testing.T) {
 				StartingBalance: sample.Coins(),
 				Options:         option,
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "invalid chain id",
 			msg: types.MsgRequestAddVestedAccount{
@@ -50,7 +49,7 @@ func TestMsgRequestAddVestedAccount_ValidateBasic(t *testing.T) {
 				StartingBalance: sample.Coins(),
 				Options:         option,
 			},
-			err: sdkerrors.Wrap(types.ErrInvalidChainID, "invalid_chain"),
+			err: types.ErrInvalidChainID,
 		}, {
 			name: "nil message option",
 			msg: types.MsgRequestAddVestedAccount{
@@ -59,7 +58,7 @@ func TestMsgRequestAddVestedAccount_ValidateBasic(t *testing.T) {
 				StartingBalance: sample.Coins(),
 				Options:         nil,
 			},
-			err: sdkerrors.Wrap(types.ErrInvalidAccountOption, addr),
+			err: types.ErrInvalidAccountOption,
 		}, {
 			name: "invalid coins",
 			msg: types.MsgRequestAddVestedAccount{
@@ -68,8 +67,7 @@ func TestMsgRequestAddVestedAccount_ValidateBasic(t *testing.T) {
 				StartingBalance: sdk.Coins{sdk.Coin{Denom: "", Amount: sdk.NewInt(10)}},
 				Options:         option,
 			},
-			err: sdkerrors.Wrap(types.ErrInvalidCoins,
-				"invalid starting balance: 10: the coin list is invalid"),
+			err: types.ErrInvalidCoins,
 		}, {
 			name: "invalid message option",
 			msg: types.MsgRequestAddVestedAccount{
@@ -78,8 +76,7 @@ func TestMsgRequestAddVestedAccount_ValidateBasic(t *testing.T) {
 				StartingBalance: sample.Coins(),
 				Options:         invalidOption,
 			},
-			err: sdkerrors.Wrap(types.ErrInvalidAccountOption,
-				"unknown vested account option type"),
+			err: types.ErrInvalidAccountOption,
 		}, {
 			name: "valid message",
 			msg: types.MsgRequestAddVestedAccount{

--- a/x/launch/types/message_request_remove_account_test.go
+++ b/x/launch/types/message_request_remove_account_test.go
@@ -23,8 +23,7 @@ func TestMsgRequestRemoveAccount_ValidateBasic(t *testing.T) {
 				Address: sample.AccAddress(),
 				ChainID: chainID1,
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid creator address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "invalid address",
 			msg: types.MsgRequestRemoveAccount{
@@ -32,8 +31,7 @@ func TestMsgRequestRemoveAccount_ValidateBasic(t *testing.T) {
 				Address: "invalid_address",
 				ChainID: chainID1,
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid account address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "invalid chain id",
 			msg: types.MsgRequestRemoveAccount{
@@ -41,7 +39,7 @@ func TestMsgRequestRemoveAccount_ValidateBasic(t *testing.T) {
 				Address: sample.AccAddress(),
 				ChainID: "invalid_chain",
 			},
-			err: sdkerrors.Wrap(types.ErrInvalidChainID, "invalid_chain"),
+			err: types.ErrInvalidChainID,
 		}, {
 			name: "valid message",
 			msg: types.MsgRequestRemoveAccount{

--- a/x/launch/types/message_request_remove_validator_test.go
+++ b/x/launch/types/message_request_remove_validator_test.go
@@ -23,8 +23,7 @@ func TestMsgRequestRemoveValidator_ValidateBasic(t *testing.T) {
 				ValidatorAddress: sample.AccAddress(),
 				ChainID:          chainID,
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid creator address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "invalid validator address",
 			msg: types.MsgRequestRemoveValidator{
@@ -32,8 +31,7 @@ func TestMsgRequestRemoveValidator_ValidateBasic(t *testing.T) {
 				ValidatorAddress: "invalid_address",
 				ChainID:          chainID,
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid validator address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "invalid chain id",
 			msg: types.MsgRequestRemoveValidator{
@@ -41,7 +39,7 @@ func TestMsgRequestRemoveValidator_ValidateBasic(t *testing.T) {
 				ValidatorAddress: sample.AccAddress(),
 				ChainID:          "invalid_chain",
 			},
-			err: sdkerrors.Wrap(types.ErrInvalidChainID, "invalid_chain"),
+			err: types.ErrInvalidChainID,
 		}, {
 			name: "valid message",
 			msg: types.MsgRequestRemoveValidator{

--- a/x/launch/types/message_settle_request_test.go
+++ b/x/launch/types/message_settle_request_test.go
@@ -24,8 +24,7 @@ func TestMsgSettleRequest_ValidateBasic(t *testing.T) {
 				RequestID:   10,
 				Approve:     true,
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid creator address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "invalid chain id",
 			msg: types.MsgSettleRequest{
@@ -34,7 +33,7 @@ func TestMsgSettleRequest_ValidateBasic(t *testing.T) {
 				RequestID:   10,
 				Approve:     true,
 			},
-			err: sdkerrors.Wrap(types.ErrInvalidChainID, "invalid_chain"),
+			err: types.ErrInvalidChainID,
 		}, {
 			name: "valid message",
 			msg: types.MsgSettleRequest{

--- a/x/launch/types/vesting_options_test.go
+++ b/x/launch/types/vesting_options_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/spn/testutil/sample"
 	"github.com/tendermint/spn/x/launch/types"
@@ -23,24 +22,21 @@ func TestDelayedVesting_Validate(t *testing.T) {
 				Vesting: nil,
 				EndTime: time.Now().Unix(),
 			},
-			err: sdkerrors.Wrap(types.ErrInvalidCoins,
-				"invalid vesting coins for DelayedVesting"),
+			err: types.ErrInvalidCoins,
 		}, {
 			name: "vesting with invalid coins",
 			option: types.DelayedVesting{
 				Vesting: sdk.Coins{sdk.Coin{Denom: "", Amount: sdk.NewInt(10)}},
 				EndTime: 0,
 			},
-			err: sdkerrors.Wrap(types.ErrInvalidCoins,
-				"invalid vesting coins for DelayedVesting: 10: the coin list is invalid"),
+			err: types.ErrInvalidCoins,
 		}, {
 			name: "vesting with invalid timestamp",
 			option: types.DelayedVesting{
 				Vesting: sample.Coins(),
 				EndTime: 0,
 			},
-			err: sdkerrors.Wrap(types.ErrInvalidTimestamp,
-				"invalid end time for DelayedVesting"),
+			err: types.ErrInvalidTimestamp,
 		}, {
 			name: "valid account vesting",
 			option: types.DelayedVesting{

--- a/x/profile/keeper/msg_server_create_coordinator_test.go
+++ b/x/profile/keeper/msg_server_create_coordinator_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/spn/testutil/sample"
 	"github.com/tendermint/spn/x/profile/types"
@@ -34,7 +33,7 @@ func TestMsgCreateCoordinator(t *testing.T) {
 		}, {
 			name: "already exist address",
 			msg:  msg2,
-			err:  sdkerrors.Wrap(types.ErrCoordAlreadyExist, "coordinatorId: 1"),
+			err:  types.ErrCoordAlreadyExist,
 		},
 	}
 	for _, tt := range tests {

--- a/x/profile/keeper/msg_server_delete_coordinator_test.go
+++ b/x/profile/keeper/msg_server_delete_coordinator_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/spn/testutil/sample"
@@ -29,7 +28,7 @@ func TestMsgDeleteCoordinator(t *testing.T) {
 		{
 			name: "not found coordinator address",
 			msg:  types.MsgDeleteCoordinator{Address: addr},
-			err:  sdkerrors.Wrap(types.ErrCoordAddressNotFound, addr),
+			err:  types.ErrCoordAddressNotFound,
 		},
 		{
 			name: "delete coordinator",

--- a/x/profile/keeper/msg_server_delete_validator_test.go
+++ b/x/profile/keeper/msg_server_delete_validator_test.go
@@ -1,11 +1,9 @@
 package keeper
 
 import (
-	"fmt"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/spn/testutil/sample"
 	"github.com/tendermint/spn/x/profile/types"
@@ -32,8 +30,7 @@ func TestMsgDeleteValidator(t *testing.T) {
 			msg: types.MsgDeleteValidator{
 				Address: addr1,
 			},
-			err: sdkerrors.Wrap(types.ErrValidatorNotFound,
-				fmt.Sprintf("validator: %s", addr1)),
+			err: types.ErrValidatorNotFound,
 		}, {
 			name: "delete an existing validator",
 			msg: types.MsgDeleteValidator{

--- a/x/profile/keeper/msg_server_update_coordinator_address_test.go
+++ b/x/profile/keeper/msg_server_update_coordinator_address_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/spn/testutil/sample"
 	"github.com/tendermint/spn/x/profile/types"
@@ -35,14 +34,14 @@ func TestMsgUpdateCoordinatorAddress(t *testing.T) {
 				Address:    addr,
 				NewAddress: addr,
 			},
-			err: sdkerrors.Wrap(types.ErrCoordAddressNotFound, addr),
+			err: types.ErrCoordAddressNotFound,
 		}, {
 			name: "new address already exist",
 			msg: types.MsgUpdateCoordinatorAddress{
 				Address:    coord1.Address,
 				NewAddress: coord2.Address,
 			},
-			err: sdkerrors.Wrap(types.ErrCoordAlreadyExist, "new address already have a coordinator: 1"),
+			err: types.ErrCoordAlreadyExist,
 		}, {
 			name: "update first coordinator address update",
 			msg: types.MsgUpdateCoordinatorAddress{
@@ -61,7 +60,7 @@ func TestMsgUpdateCoordinatorAddress(t *testing.T) {
 				Address:    addr,
 				NewAddress: coord1.Address,
 			},
-			err: sdkerrors.Wrap(types.ErrCoordAlreadyExist, "new address already have a coordinator: 0"),
+			err: types.ErrCoordAlreadyExist,
 		},
 	}
 	for _, tt := range tests {

--- a/x/profile/keeper/msg_server_update_coordinator_description_test.go
+++ b/x/profile/keeper/msg_server_update_coordinator_description_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/spn/testutil/sample"
 	"github.com/tendermint/spn/x/profile/types"
@@ -30,7 +29,7 @@ func TestMsgUpdateCoordinatorDescription(t *testing.T) {
 			msg: types.MsgUpdateCoordinatorDescription{
 				Address: addr,
 			},
-			err: sdkerrors.Wrap(types.ErrCoordAddressNotFound, addr),
+			err: types.ErrCoordAddressNotFound,
 		}, {
 			name: "update one value",
 			msg: types.MsgUpdateCoordinatorDescription{

--- a/x/profile/types/genesis_test.go
+++ b/x/profile/types/genesis_test.go
@@ -10,9 +10,7 @@ import (
 )
 
 func TestGenesisStateValidateValidator(t *testing.T) {
-	var (
-		addr = sample.AccAddress()
-	)
+	addr := sample.AccAddress()
 	tests := []struct {
 		name     string
 		genState *profile.GenesisState

--- a/x/profile/types/message_create_coordinator_test.go
+++ b/x/profile/types/message_create_coordinator_test.go
@@ -20,8 +20,7 @@ func TestMsgCreateCoordinator_ValidateBasic(t *testing.T) {
 			msg: profile.MsgCreateCoordinator{
 				Address: "invalid address",
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "valid address",
 			msg: profile.MsgCreateCoordinator{

--- a/x/profile/types/message_delete_coordinator_test.go
+++ b/x/profile/types/message_delete_coordinator_test.go
@@ -20,8 +20,7 @@ func TestMsgDeleteCoordinator_ValidateBasic(t *testing.T) {
 			msg: profile.MsgDeleteCoordinator{
 				Address: "invalid address",
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "valid address",
 			msg: profile.MsgDeleteCoordinator{

--- a/x/profile/types/message_delete_validator_test.go
+++ b/x/profile/types/message_delete_validator_test.go
@@ -20,8 +20,7 @@ func TestMsgDeleteValidator_ValidateBasic(t *testing.T) {
 			msg: profile.MsgDeleteValidator{
 				Address: "invalid address",
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "valid address",
 			msg: profile.MsgDeleteValidator{

--- a/x/profile/types/message_update_coordinator_address_test.go
+++ b/x/profile/types/message_update_coordinator_address_test.go
@@ -22,16 +22,14 @@ func TestMsgUpdateCoordinatorAddress_ValidateBasic(t *testing.T) {
 				Address:    "invalid address",
 				NewAddress: sample.AccAddress(),
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "invalid new address",
 			msg: profile.MsgUpdateCoordinatorAddress{
 				Address:    sample.AccAddress(),
 				NewAddress: "invalid address",
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid new address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "equal addresses",
 			msg: profile.MsgUpdateCoordinatorAddress{

--- a/x/profile/types/message_update_coordinator_description_test.go
+++ b/x/profile/types/message_update_coordinator_description_test.go
@@ -21,22 +21,21 @@ func TestMsgUpdateCoordinatorDescription_ValidateBasic(t *testing.T) {
 			msg: profile.MsgUpdateCoordinatorDescription{
 				Address: "invalid address",
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "valid address and empty description",
 			msg: profile.MsgUpdateCoordinatorDescription{
 				Address:     addr,
 				Description: &profile.CoordinatorDescription{},
 			},
-			err: sdkerrors.Wrap(profile.ErrEmptyDescription, addr),
+			err: profile.ErrEmptyDescription,
 		}, {
 			name: "valid address and nil description",
 			msg: profile.MsgUpdateCoordinatorDescription{
 				Address:     addr,
 				Description: nil,
 			},
-			err: sdkerrors.Wrap(profile.ErrEmptyDescription, addr),
+			err: profile.ErrEmptyDescription,
 		}, {
 			name: "valid address and description",
 			msg: profile.MsgUpdateCoordinatorDescription{

--- a/x/profile/types/message_update_validator_description_test.go
+++ b/x/profile/types/message_update_validator_description_test.go
@@ -21,22 +21,21 @@ func TestMsgUpdateValidatorDescription_ValidateBasic(t *testing.T) {
 			msg: profile.MsgUpdateValidatorDescription{
 				Address: "invalid address",
 			},
-			err: sdkerrors.Wrap(sdkerrors.ErrInvalidAddress,
-				"invalid address (invalid_address): decoding bech32 failed: invalid index of 1"),
+			err: sdkerrors.ErrInvalidAddress,
 		}, {
 			name: "valid address and empty description",
 			msg: profile.MsgUpdateValidatorDescription{
 				Address:     addr,
 				Description: &profile.ValidatorDescription{},
 			},
-			err: sdkerrors.Wrap(profile.ErrEmptyDescription, addr),
+			err: profile.ErrEmptyDescription,
 		}, {
 			name: "valid address and nil description",
 			msg: profile.MsgUpdateValidatorDescription{
 				Address:     addr,
 				Description: nil,
 			},
-			err: sdkerrors.Wrap(profile.ErrEmptyDescription, addr),
+			err: profile.ErrEmptyDescription,
 		}, {
 			name: "valid address and description",
 			msg: profile.MsgUpdateValidatorDescription{


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

### What does this PR does?

Assert only the error type using the `require.ErrorIs` method from `testify` and remove the error message assertion.

### How to test?

```shell
$ make test
```
