### PR TITLE
ci: disable codecov/patch status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,6 +3,7 @@ coverage:
   round: down
   precision: 2
   status:
+    patch: off
     changes: false
     project:
       default:


### PR DESCRIPTION
Remove the `codecov/patch` status from the CI since it is not necessary and sometime fails. We use codecov to get an absolute view of the coverare
