### PR TITLE
feat(campaign): create `shares` type

### DIFF
--- a/testutil/sample/campaign.go
+++ b/testutil/sample/campaign.go
@@ -2,6 +2,11 @@ package sample
 
 import campaign "github.com/tendermint/spn/x/campaign/types"
 
+// Shares returns a sample shares
+func Shares() campaign.Shares {
+	return campaign.NewSharesFromCoins(Coins())
+}
+
 // CampaignGenesisState returns a sample genesis state for the campaign module
 func CampaignGenesisState() campaign.GenesisState {
 	return campaign.GenesisState{}

--- a/x/campaign/types/share.go
+++ b/x/campaign/types/share.go
@@ -1,0 +1,48 @@
+package types
+
+import (
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"strings"
+)
+
+// Shares represents the portion of a supply
+type Shares sdk.Coins
+
+const (
+	// DefaultTotalShare is the default value of total share for an underlying supply asset
+	DefaultTotalShare = 100000
+
+	// SharePrefix is the prefix used to represent a share denomination
+	// A sdk.Coin containing this prefix must never be represented in a balance in the bank module
+	SharePrefix = "s/"
+)
+
+// NewShares returns new shares from comma-separated value (100atom,200iris...)
+func NewShares(shareStr string) (Shares, error) {
+	coins, err := sdk.ParseCoinsNormalized(shareStr)
+	if err != nil {
+		return nil, err
+	}
+	return NewSharesFromCoins(coins), nil
+}
+
+// NewSharesFromCoins returns new shares from the coins representation
+func NewSharesFromCoins(coins sdk.Coins) Shares {
+	for _, coin := range coins {
+		coin.Denom = SharePrefix + coin.Denom
+	}
+
+	return Shares(coins)
+}
+
+// CheckShares checks if given shares are valid shares
+func CheckShares(shares Shares) error {
+	for _, coin := range shares {
+		if !strings.HasPrefix(coin.Denom, SharePrefix) {
+			fmt.Errorf("%s doesn't contain the share prefix %s", coin.Denom, SharePrefix)
+		}
+	}
+
+	return nil
+}

--- a/x/campaign/types/shares.go
+++ b/x/campaign/types/shares.go
@@ -3,8 +3,9 @@ package types
 import (
 	"errors"
 	"fmt"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Shares represents the portion of a supply
@@ -46,7 +47,7 @@ func NewSharesFromCoins(coins sdk.Coins) Shares {
 func CheckShares(shares Shares) error {
 	for _, coin := range shares {
 		if !strings.HasPrefix(coin.Denom, SharePrefix) {
-			fmt.Errorf("%s doesn't contain the share prefix %s", coin.Denom, SharePrefix)
+			return fmt.Errorf("%s doesn't contain the share prefix %s", coin.Denom, SharePrefix)
 		}
 	}
 
@@ -81,7 +82,7 @@ func IsTotalReached(shares, totalShares Shares) bool {
 		// If the denom is not specifed in total share, we compare the default total share number
 		total, ok := totalMap[coin.Denom]
 		if ok {
-			if coin.Amount.Uint64() > total{
+			if coin.Amount.Uint64() > total {
 				return true
 			}
 		} else {

--- a/x/campaign/types/shares.go
+++ b/x/campaign/types/shares.go
@@ -72,14 +72,14 @@ func DecreaseShares(shares, toDecrease Shares) (Shares, error) {
 // IsTotalReached checks if the provided shares overflow the total number of shares
 // Denoms not specified in totalShares uses DefaultTotalShareNumber as the default number of total shares
 func IsTotalReached(shares, totalShares Shares) bool {
-	// Check the explicitely defined total shares
+	// Check the explicitly defined total shares
 	totalMap := make(map[string]uint64)
 	for _, coin := range totalShares {
 		totalMap[coin.Denom] = coin.Amount.Uint64()
 	}
 
 	for _, coin := range shares {
-		// If the denom is not specifed in total share, we compare the default total share number
+		// If the denom is not specified in total share, we compare the default total share number
 		total, ok := totalMap[coin.Denom]
 		if ok {
 			if coin.Amount.Uint64() > total {

--- a/x/campaign/types/shares.go
+++ b/x/campaign/types/shares.go
@@ -29,8 +29,8 @@ func NewShares(shareStr string) (Shares, error) {
 
 // NewSharesFromCoins returns new shares from the coins representation
 func NewSharesFromCoins(coins sdk.Coins) Shares {
-	for _, coin := range coins {
-		coin.Denom = SharePrefix + coin.Denom
+	for i := range coins {
+		coins[i].Denom = SharePrefix + coins[i].Denom
 	}
 
 	return Shares(coins)

--- a/x/campaign/types/shares.go
+++ b/x/campaign/types/shares.go
@@ -52,6 +52,11 @@ func CheckShares(shares Shares) error {
 	return nil
 }
 
+// IncreaseShares return increases the value of shares
+func IncreaseShares(shares, newShares Shares) Shares {
+	return Shares(sdk.Coins(shares).Add(sdk.Coins(newShares)...))
+}
+
 // IsTotalReached checks if the provided shares overflow the total number of shares
 // Denoms not specified in totalShares uses DefaultTotalShareNumber as the default number of total shares
 func IsTotalReached(shares, totalShares Shares) bool {

--- a/x/campaign/types/shares.go
+++ b/x/campaign/types/shares.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"strings"
@@ -52,9 +53,19 @@ func CheckShares(shares Shares) error {
 	return nil
 }
 
-// IncreaseShares return increases the value of shares
+// IncreaseShares increases the number of shares
 func IncreaseShares(shares, newShares Shares) Shares {
 	return Shares(sdk.Coins(shares).Add(sdk.Coins(newShares)...))
+}
+
+// DecreaseShares decreases the number of shares or returns a error if shares can't be decreased
+func DecreaseShares(shares, toDecrease Shares) (Shares, error) {
+	decreasedCoins, negative := sdk.Coins(shares).SafeSub(sdk.Coins(toDecrease))
+	if negative {
+		return nil, errors.New("shares cannot be decreased to negative")
+	}
+
+	return Shares(decreasedCoins), nil
 }
 
 // IsTotalReached checks if the provided shares overflow the total number of shares
@@ -81,6 +92,6 @@ func IsTotalReached(shares, totalShares Shares) bool {
 	}
 
 	// denoms defined in totalShares but not in shares are not checked
-	// the number if shares for an undefined denom is 0 by default therefore the total is never reached
+	// the number of shares for an undefined denom is 0 by default therefore the total is never reached
 	return false
 }

--- a/x/campaign/types/shares_test.go
+++ b/x/campaign/types/shares_test.go
@@ -7,6 +7,11 @@ import (
 	"testing"
 )
 
+func TestEmptyShares(t *testing.T) {
+	shares := campaign.EmptyShares()
+	require.Equal(t, shares, campaign.Shares(sdk.NewCoins()))
+}
+
 func TestNewShares(t *testing.T) {
 	_, err := campaign.NewShares("invalid")
 	require.Error(t, err)
@@ -39,4 +44,66 @@ func TestCheckShares(t *testing.T) {
 		sdk.NewCoin("foo", sdk.NewInt(100)),
 		sdk.NewCoin(campaign.SharePrefix + "bar", sdk.NewInt(200)),
 	))))
+}
+
+func TestIsTotalReached(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		shares campaign.Shares
+		totalShares campaign.Shares
+		reached    bool
+	}{
+		{
+			desc:     "empty is false",
+			shares: campaign.EmptyShares(),
+			totalShares: campaign.EmptyShares(),
+			reached: false,
+		},
+		{
+			desc:     "no default total is reached",
+			shares: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin("foo", sdk.NewInt(campaign.DefaultTotalShareNumber)),
+				sdk.NewCoin("bar", sdk.NewInt(100)),
+				)),
+			totalShares: campaign.EmptyShares(),
+			reached: false,
+		},
+		{
+			desc:     "no custom total is reached",
+			shares: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin("foo", sdk.NewInt(100)),
+				sdk.NewCoin("bar", sdk.NewInt(50)),
+			)),
+			totalShares: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin("foo", sdk.NewInt(100)),
+				sdk.NewCoin("bar", sdk.NewInt(100)),
+				sdk.NewCoin("foobar", sdk.NewInt(100)),
+			)),
+			reached: false,
+		},
+		{
+			desc:     "a default total is reached",
+			shares: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin("foo", sdk.NewInt(campaign.DefaultTotalShareNumber+1)),
+				sdk.NewCoin("bar", sdk.NewInt(100)),
+			)),
+			totalShares: campaign.EmptyShares(),
+			reached: true,
+		},
+		{
+			desc:     "a custom total is reached",
+			shares: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin("foo", sdk.NewInt(campaign.DefaultTotalShareNumber)),
+				sdk.NewCoin("bar", sdk.NewInt(101)),
+			)),
+			totalShares: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin("bar", sdk.NewInt(100)),
+			)),
+			reached: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.reached, campaign.IsTotalReached(tc.shares, tc.totalShares))
+		})
+	}
 }

--- a/x/campaign/types/shares_test.go
+++ b/x/campaign/types/shares_test.go
@@ -107,6 +107,75 @@ func TestIncreaseShares(t *testing.T) {
 	}
 }
 
+func TestDecreaseShares(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		shares campaign.Shares
+		toDecrease campaign.Shares
+		expected    campaign.Shares
+		isError bool
+	} {
+		{
+			desc: "decrease empty set",
+			shares: campaign.EmptyShares(),
+			toDecrease: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin(prefixedFoo, sdk.NewInt(100)),
+				sdk.NewCoin(prefixedBar, sdk.NewInt(100)),
+			)),
+			isError: true,
+		},
+		{
+			desc: "decrease from empty set",
+			shares: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin(prefixedFoo, sdk.NewInt(100)),
+				sdk.NewCoin(prefixedBar, sdk.NewInt(100)),
+			)),
+			toDecrease: campaign.EmptyShares(),
+			expected: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin(prefixedFoo, sdk.NewInt(100)),
+				sdk.NewCoin(prefixedBar, sdk.NewInt(100)),
+			)),
+		},
+		{
+			desc: "decrease to negative",
+			shares: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin(prefixedFoo, sdk.NewInt(100)),
+				sdk.NewCoin(prefixedBar, sdk.NewInt(50)),
+			)),
+			toDecrease: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin(prefixedFoo, sdk.NewInt(100)),
+				sdk.NewCoin(prefixedBar, sdk.NewInt(100)),
+			)),
+			isError: true,
+		},
+		{
+			desc: "decrease normal set",
+			shares: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin(prefixedFoo, sdk.NewInt(100)),
+				sdk.NewCoin(prefixedBar, sdk.NewInt(100)),
+				sdk.NewCoin(prefixedFoobar, sdk.NewInt(50)),
+			)),
+			toDecrease: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin(prefixedFoo, sdk.NewInt(30)),
+				sdk.NewCoin(prefixedBar, sdk.NewInt(100)),
+			)),
+			expected: campaign.NewSharesFromCoins(sdk.NewCoins(
+				sdk.NewCoin(prefixedFoo, sdk.NewInt(70)),
+				sdk.NewCoin(prefixedBar, sdk.NewInt(0)),
+				sdk.NewCoin(prefixedFoobar, sdk.NewInt(50)),
+			)),
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			decreased, err := campaign.DecreaseShares(tc.shares, tc.toDecrease)
+			require.Equal(t, tc.isError, err != nil)
+			if !tc.isError {
+				require.Equal(t, tc.expected, decreased)
+			}
+		})
+	}
+}
+
 func TestIsTotalReached(t *testing.T) {
 	for _, tc := range []struct {
 		desc     string

--- a/x/campaign/types/shares_test.go
+++ b/x/campaign/types/shares_test.go
@@ -1,15 +1,16 @@
 package types_test
 
 import (
+	"testing"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	campaign "github.com/tendermint/spn/x/campaign/types"
-	"testing"
 )
 
 var (
-	prefixedFoo = campaign.SharePrefix + "foo"
-	prefixedBar = campaign.SharePrefix + "bar"
+	prefixedFoo    = campaign.SharePrefix + "foo"
+	prefixedBar    = campaign.SharePrefix + "bar"
 	prefixedFoobar = campaign.SharePrefix + "foobar"
 )
 
@@ -46,7 +47,7 @@ func TestCheckShares(t *testing.T) {
 		sdk.NewCoin(prefixedFoo, sdk.NewInt(100)),
 		sdk.NewCoin(prefixedBar, sdk.NewInt(200)),
 	))))
-	require.NoError(t, campaign.CheckShares(campaign.Shares(sdk.NewCoins(
+	require.Error(t, campaign.CheckShares(campaign.Shares(sdk.NewCoins(
 		sdk.NewCoin("foo", sdk.NewInt(100)),
 		sdk.NewCoin(prefixedBar, sdk.NewInt(200)),
 	))))
@@ -54,13 +55,13 @@ func TestCheckShares(t *testing.T) {
 
 func TestIncreaseShares(t *testing.T) {
 	for _, tc := range []struct {
-		desc     string
-		shares campaign.Shares
+		desc      string
+		shares    campaign.Shares
 		newShares campaign.Shares
-		expected    campaign.Shares
-	} {
+		expected  campaign.Shares
+	}{
 		{
-			desc: "increase empty set",
+			desc:   "increase empty set",
 			shares: campaign.EmptyShares(),
 			newShares: campaign.NewSharesFromCoins(sdk.NewCoins(
 				sdk.NewCoin(prefixedFoo, sdk.NewInt(100)),
@@ -109,14 +110,14 @@ func TestIncreaseShares(t *testing.T) {
 
 func TestDecreaseShares(t *testing.T) {
 	for _, tc := range []struct {
-		desc     string
-		shares campaign.Shares
+		desc       string
+		shares     campaign.Shares
 		toDecrease campaign.Shares
-		expected    campaign.Shares
-		isError bool
-	} {
+		expected   campaign.Shares
+		isError    bool
+	}{
 		{
-			desc: "decrease empty set",
+			desc:   "decrease empty set",
 			shares: campaign.EmptyShares(),
 			toDecrease: campaign.NewSharesFromCoins(sdk.NewCoins(
 				sdk.NewCoin(prefixedFoo, sdk.NewInt(100)),
@@ -178,28 +179,28 @@ func TestDecreaseShares(t *testing.T) {
 
 func TestIsTotalReached(t *testing.T) {
 	for _, tc := range []struct {
-		desc     string
-		shares campaign.Shares
+		desc        string
+		shares      campaign.Shares
 		totalShares campaign.Shares
-		reached    bool
+		reached     bool
 	}{
 		{
-			desc:     "empty is false",
-			shares: campaign.EmptyShares(),
+			desc:        "empty is false",
+			shares:      campaign.EmptyShares(),
 			totalShares: campaign.EmptyShares(),
-			reached: false,
+			reached:     false,
 		},
 		{
-			desc:     "no default total is reached",
+			desc: "no default total is reached",
 			shares: campaign.NewSharesFromCoins(sdk.NewCoins(
 				sdk.NewCoin(prefixedFoo, sdk.NewInt(campaign.DefaultTotalShareNumber)),
 				sdk.NewCoin(prefixedBar, sdk.NewInt(100)),
-				)),
+			)),
 			totalShares: campaign.EmptyShares(),
-			reached: false,
+			reached:     false,
 		},
 		{
-			desc:     "no custom total is reached",
+			desc: "no custom total is reached",
 			shares: campaign.NewSharesFromCoins(sdk.NewCoins(
 				sdk.NewCoin(prefixedFoo, sdk.NewInt(100)),
 				sdk.NewCoin(prefixedBar, sdk.NewInt(50)),
@@ -212,16 +213,16 @@ func TestIsTotalReached(t *testing.T) {
 			reached: false,
 		},
 		{
-			desc:     "a default total is reached",
+			desc: "a default total is reached",
 			shares: campaign.NewSharesFromCoins(sdk.NewCoins(
 				sdk.NewCoin(prefixedFoo, sdk.NewInt(campaign.DefaultTotalShareNumber+1)),
 				sdk.NewCoin(prefixedBar, sdk.NewInt(100)),
 			)),
 			totalShares: campaign.EmptyShares(),
-			reached: true,
+			reached:     true,
 		},
 		{
-			desc:     "a custom total is reached",
+			desc: "a custom total is reached",
 			shares: campaign.NewSharesFromCoins(sdk.NewCoins(
 				sdk.NewCoin(prefixedFoo, sdk.NewInt(campaign.DefaultTotalShareNumber)),
 				sdk.NewCoin(prefixedBar, sdk.NewInt(101)),

--- a/x/campaign/types/shares_test.go
+++ b/x/campaign/types/shares_test.go
@@ -1,0 +1,42 @@
+package types_test
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	campaign "github.com/tendermint/spn/x/campaign/types"
+	"testing"
+)
+
+func TestNewShares(t *testing.T) {
+	_, err := campaign.NewShares("invalid")
+	require.Error(t, err)
+
+	shares, err := campaign.NewShares("100foo,200bar")
+	require.NoError(t, err)
+	require.Equal(t, shares, campaign.Shares(sdk.NewCoins(
+		sdk.NewCoin(campaign.SharePrefix + "foo", sdk.NewInt(100)),
+		sdk.NewCoin(campaign.SharePrefix + "bar", sdk.NewInt(200)),
+	)))
+}
+
+func TestNewSharesFromCoins(t *testing.T) {
+	shares := campaign.NewSharesFromCoins(sdk.NewCoins(
+		sdk.NewCoin("foo", sdk.NewInt(100)),
+		sdk.NewCoin("bar", sdk.NewInt(200)),
+	))
+	require.Equal(t, shares, campaign.Shares(sdk.NewCoins(
+		sdk.NewCoin(campaign.SharePrefix + "foo", sdk.NewInt(100)),
+		sdk.NewCoin(campaign.SharePrefix + "bar", sdk.NewInt(200)),
+	)))
+}
+
+func TestCheckShares(t *testing.T) {
+	require.NoError(t, campaign.CheckShares(campaign.Shares(sdk.NewCoins(
+		sdk.NewCoin(campaign.SharePrefix + "foo", sdk.NewInt(100)),
+		sdk.NewCoin(campaign.SharePrefix + "bar", sdk.NewInt(200)),
+	))))
+	require.NoError(t, campaign.CheckShares(campaign.Shares(sdk.NewCoins(
+		sdk.NewCoin("foo", sdk.NewInt(100)),
+		sdk.NewCoin(campaign.SharePrefix + "bar", sdk.NewInt(200)),
+	))))
+}


### PR DESCRIPTION
`Shares` simply reuse the type `sdk.Coins` since it represents denoms associated with an amount.

We add here the prefix `s/` to distinguish it from other coins in the store