### PR TITLE
test(`simapp`): reduce block size

### DIFF
--- a/app/simulation_test.go
+++ b/app/simulation_test.go
@@ -58,7 +58,7 @@ var defaultConsensusParams = &abci.ConsensusParams{
 func BenchmarkSimulation(b *testing.B) {
 	simapp.FlagEnabledValue = true
 	simapp.FlagNumBlocksValue = 200
-	simapp.FlagBlockSizeValue = 50
+	simapp.FlagBlockSizeValue = 26
 	simapp.FlagCommitValue = true
 	simapp.FlagVerboseValue = true
 


### PR DESCRIPTION
Reduce `FlagBlockSizeValue` to prevent insufficient gas error to occur during simulation tests until we figure out: https://github.com/tendermint/spn/issues/369
