### PR TITLE
refactor(`launch`): set initial launch ID counter to `1`

### DIFF
--- a/x/launch/types/genesis.go
+++ b/x/launch/types/genesis.go
@@ -7,7 +7,7 @@ func DefaultGenesis() *GenesisState {
 	return &GenesisState{
 		// this line is used by starport scaffolding # genesis/types/default
 		ChainList:            []Chain{},
-		ChainCount:           0,
+		ChainCount:           1,
 		GenesisAccountList:   []GenesisAccount{},
 		VestingAccountList:   []VestingAccount{},
 		GenesisValidatorList: []GenesisValidator{},


### PR DESCRIPTION
As needed for the `network init` command refactor
