### PR TITLE
refactor(`launch`): set temporary params `DefaultMinLaunchTime`

### DIFF
--- a/x/launch/types/params.go
+++ b/x/launch/types/params.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	// DefaultMinLaunchTime
+	// DefaultMinLaunchTime ...
 	// TODO: set back this value to the defaut one
 	// uint64(time.Hour.Seconds() * 24)
 	DefaultMinLaunchTime = uint64(5)

--- a/x/launch/types/params.go
+++ b/x/launch/types/params.go
@@ -9,9 +9,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// TODO: Determine default values
 var (
-	DefaultMinLaunchTime = uint64(time.Hour.Seconds() * 24)
+	// DefaultMinLaunchTime
+	// TODO: set back this value to the defaut one
+	// uint64(time.Hour.Seconds() * 24)
+	DefaultMinLaunchTime = uint64(5)
 	DefaultMaxLaunchTime = uint64(time.Hour.Seconds() * 24 * 7)
 
 	MaxParametrableLaunchTime = uint64(time.Hour.Seconds() * 24 * 31)


### PR DESCRIPTION
Set a temporary value for `DefaultMinLaunchTime` of 5 secondes for test purpose since the Starport config is sometime not used by all tools we use