### PR TITLE
refactor: use `UintBytes` helper to convert uint64 keys

### DIFF
--- a/x/campaign/keeper/campaign.go
+++ b/x/campaign/keeper/campaign.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	spntypes "github.com/tendermint/spn/pkg/types"
 	"github.com/tendermint/spn/x/campaign/types"
 )
 
@@ -92,9 +93,7 @@ func (k Keeper) GetAllCampaign(ctx sdk.Context) (list []types.Campaign) {
 
 // GetCampaignIDBytes returns the byte representation of the ID
 func GetCampaignIDBytes(id uint64) []byte {
-	bz := make([]byte, 8)
-	binary.BigEndian.PutUint64(bz, id)
-	return bz
+	return spntypes.UintBytes(id)
 }
 
 // GetCampaignIDFromBytes returns ID in uint64 format from a byte array

--- a/x/launch/keeper/genesis_validator.go
+++ b/x/launch/keeper/genesis_validator.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"encoding/base64"
+
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/spn/x/launch/types"

--- a/x/launch/keeper/validator_set.go
+++ b/x/launch/keeper/validator_set.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"encoding/base64"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/tendermint/spn/x/launch/types"

--- a/x/launch/types/key_request.go
+++ b/x/launch/types/key_request.go
@@ -1,6 +1,8 @@
 package types
 
-import spntypes "github.com/tendermint/spn/pkg/types"
+import (
+	spntypes "github.com/tendermint/spn/pkg/types"
+)
 
 const (
 	// RequestKeyPrefix is the prefix to retrieve all Request

--- a/x/monitoringc/keeper/handshake_test.go
+++ b/x/monitoringc/keeper/handshake_test.go
@@ -19,16 +19,16 @@ func monitoringcKeeperWithFooClient(t *testing.T) (*monitoringcmodulekeeper.Keep
 		t,
 		[]testkeeper.Connection{
 			{
-				"foo",
-				connectiontypes.ConnectionEnd{
+				ConnID: "foo",
+				Conn: connectiontypes.ConnectionEnd{
 					ClientId: "foo",
 				},
 			},
 		},
 		[]testkeeper.Channel{
 			{
-				"foo",
-				channeltypes.Channel{
+				ChannelID: "foo",
+				Channel: channeltypes.Channel{
 					ConnectionHops: []string{"foo"},
 				},
 			},
@@ -59,8 +59,8 @@ func TestKeeper_VerifyClientIDFromChannelID(t *testing.T) {
 			[]testkeeper.Connection{},
 			[]testkeeper.Channel{
 				{
-					"foo",
-					channeltypes.Channel{
+					ChannelID: "foo",
+					Channel: channeltypes.Channel{
 						ConnectionHops: []string{"foo", "bar"},
 					},
 				},
@@ -76,8 +76,8 @@ func TestKeeper_VerifyClientIDFromChannelID(t *testing.T) {
 			[]testkeeper.Connection{},
 			[]testkeeper.Channel{
 				{
-					"foo",
-					channeltypes.Channel{
+					ChannelID: "foo",
+					Channel: channeltypes.Channel{
 						ConnectionHops: []string{"foo"},
 					},
 				},
@@ -172,8 +172,8 @@ func TestKeeper_RegisterProviderClientIDFromChannelID(t *testing.T) {
 			[]testkeeper.Connection{},
 			[]testkeeper.Channel{
 				{
-					"foo",
-					channeltypes.Channel{
+					ChannelID: "foo",
+					Channel: channeltypes.Channel{
 						ConnectionHops: []string{"foo", "bar"},
 					},
 				},
@@ -189,8 +189,8 @@ func TestKeeper_RegisterProviderClientIDFromChannelID(t *testing.T) {
 			[]testkeeper.Connection{},
 			[]testkeeper.Channel{
 				{
-					"foo",
-					channeltypes.Channel{
+					ChannelID: "foo",
+					Channel: channeltypes.Channel{
 						ConnectionHops: []string{"foo"},
 					},
 				},

--- a/x/monitoringc/types/key_launch_id_from_channel_id.go
+++ b/x/monitoringc/types/key_launch_id_from_channel_id.go
@@ -1,23 +1,11 @@
 package types
 
-import "encoding/binary"
-
-var _ binary.ByteOrder
-
 const (
 	// LaunchIDFromChannelIDKeyPrefix is the prefix to retrieve all LaunchIDFromChannelID
 	LaunchIDFromChannelIDKeyPrefix = "LaunchIDFromChannelID/value/"
 )
 
 // LaunchIDFromChannelIDKey returns the store key to retrieve a LaunchIDFromChannelID from the index fields
-func LaunchIDFromChannelIDKey(
-	channelID string,
-) []byte {
-	var key []byte
-
-	channelIDBytes := []byte(channelID)
-	key = append(key, channelIDBytes...)
-	key = append(key, []byte("/")...)
-
-	return key
+func LaunchIDFromChannelIDKey(channelID string) []byte {
+	return []byte(channelID + "/")
 }

--- a/x/monitoringc/types/key_provider_client_id.go
+++ b/x/monitoringc/types/key_provider_client_id.go
@@ -1,6 +1,8 @@
 package types
 
-import "encoding/binary"
+import (
+	spntypes "github.com/tendermint/spn/pkg/types"
+)
 
 const (
 	// ProviderClientIDKeyPrefix is the prefix to retrieve all ProviderClientID
@@ -9,12 +11,5 @@ const (
 
 // ProviderClientIDKey returns the store key to retrieve a ProviderClientID from the index fields
 func ProviderClientIDKey(launchID uint64) []byte {
-	var key []byte
-
-	launchIDBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(launchIDBytes, launchID)
-	key = append(key, launchIDBytes...)
-	key = append(key, []byte("/")...)
-
-	return key
+	return append(spntypes.UintBytes(launchID), byte('/'))
 }

--- a/x/monitoringc/types/key_verified_client_id.go
+++ b/x/monitoringc/types/key_verified_client_id.go
@@ -1,6 +1,8 @@
 package types
 
-import "encoding/binary"
+import (
+	spntypes "github.com/tendermint/spn/pkg/types"
+)
 
 const (
 	// VerifiedClientIDKeyPrefix is the prefix to retrieve all VerifiedClientID
@@ -9,9 +11,7 @@ const (
 
 // VerifiedClientIDsFomLaunchIDKey returns the store key to retrieve client ids from a launch ID
 func VerifiedClientIDsFomLaunchIDKey(launchID uint64) []byte {
-	launchIDBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(launchIDBytes, launchID)
-	return append(launchIDBytes, []byte("/")...)
+	return append(spntypes.UintBytes(launchID), byte('/'))
 }
 
 // VerifiedClientIDKey returns the store key to retrieve a VerifiedClientID from the index fields

--- a/x/monitoringp/keeper/handshake_test.go
+++ b/x/monitoringp/keeper/handshake_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	spntypes "github.com/tendermint/spn/pkg/types"
 	connectiontypes "github.com/cosmos/ibc-go/v2/modules/core/03-connection/types"
 	channeltypes "github.com/cosmos/ibc-go/v2/modules/core/04-channel/types"
 	"github.com/stretchr/testify/require"
 	spnerrors "github.com/tendermint/spn/pkg/errors"
+	spntypes "github.com/tendermint/spn/pkg/types"
 	testkeeper "github.com/tendermint/spn/testutil/keeper"
 	monitoringpmodulekeeper "github.com/tendermint/spn/x/monitoringp/keeper"
 	"github.com/tendermint/spn/x/monitoringp/types"

--- a/x/monitoringp/keeper/handshake_test.go
+++ b/x/monitoringp/keeper/handshake_test.go
@@ -20,16 +20,16 @@ func monitoringpKeeperWithFooClient(t *testing.T) (*monitoringpmodulekeeper.Keep
 		t,
 		[]testkeeper.Connection{
 			{
-				"foo",
-				connectiontypes.ConnectionEnd{
+				ConnID: "foo",
+				Conn: connectiontypes.ConnectionEnd{
 					ClientId: "foo",
 				},
 			},
 		},
 		[]testkeeper.Channel{
 			{
-				"foo",
-				channeltypes.Channel{
+				ChannelID: "foo",
+				Channel: channeltypes.Channel{
 					ConnectionHops: []string{"foo"},
 				},
 			},
@@ -63,8 +63,8 @@ func TestKeeper_VerifyClientIDFromChannelID(t *testing.T) {
 			[]testkeeper.Connection{},
 			[]testkeeper.Channel{
 				{
-					"foo",
-					channeltypes.Channel{
+					ChannelID: "foo",
+					Channel: channeltypes.Channel{
 						ConnectionHops: []string{"foo", "bar"},
 					},
 				},
@@ -83,8 +83,8 @@ func TestKeeper_VerifyClientIDFromChannelID(t *testing.T) {
 			[]testkeeper.Connection{},
 			[]testkeeper.Channel{
 				{
-					"foo",
-					channeltypes.Channel{
+					ChannelID: "foo",
+					Channel: channeltypes.Channel{
 						ConnectionHops: []string{"foo"},
 					},
 				},

--- a/x/monitoringp/module.go
+++ b/x/monitoringp/module.go
@@ -79,7 +79,7 @@ func (AppModuleBasic) RegisterRESTRoutes(clientCtx client.Context, rtr *mux.Rout
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)) // nolint
 }
 
 // GetTxCmd returns the capability module's root tx command.

--- a/x/monitoringp/types/codec.go
+++ b/x/monitoringp/types/codec.go
@@ -3,8 +3,8 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
-	// this line is used by starport scaffolding # 1
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
+	// this line is used by starport scaffolding # 1
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {

--- a/x/profile/keeper/coordinator.go
+++ b/x/profile/keeper/coordinator.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	spntypes "github.com/tendermint/spn/pkg/types"
 	"github.com/tendermint/spn/x/profile/types"
 )
 
@@ -101,7 +102,5 @@ func (k Keeper) GetCoordinatorAddressFromID(ctx sdk.Context, id uint64) (string,
 
 // GetCoordinatorIDBytes returns the byte representation of the ID
 func GetCoordinatorIDBytes(id uint64) []byte {
-	bz := make([]byte, 8)
-	binary.BigEndian.PutUint64(bz, id)
-	return bz
+	return spntypes.UintBytes(id)
 }

--- a/x/reward/types/codec.go
+++ b/x/reward/types/codec.go
@@ -3,8 +3,8 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
-	// this line is used by starport scaffolding # 1
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
+	// this line is used by starport scaffolding # 1
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {


### PR DESCRIPTION
## Description

- Use `UintBytes` helper method to make uint64 to byte slice conversion
- Fix some lint issues