### PR TITLE
chore: goimports added to format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,13 @@ govet:
 	@echo Running go vet...
 	@go vet ./...
 
-## format: Run gofmt.
+FIND_ARGS := -name '*.go' -type f -not -name '*.pb.go'
+
+## format: Run gofmt and goimports.
 format:
 	@echo Formatting...
-	@find . -name '*.go' -type f | xargs gofmt -d -s
+	@find . $(FIND_ARGS) | xargs gofmt -d -s
+	@find . $(FIND_ARGS) | xargs goimports -w -local github.com/tendermint/spn
 
 ## lint: Run Golang CI Lint.
 lint:


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

### What does this PR does?

<!-- Describe your changes here - ideally you can get that description straight from
your descriptive commit message(s)! -->

Add a step in the `make format` step to run `goimports` along with the existing step of running `gofmt`.  Occasionally, the linter complains about `goimports` errors, so adding this will take care of those issues automatically.

### How to test?

Run the new `make format` command.

If we want this minor addition, we can run `make format` on the repo and add this in a separate PR.  It will just modify the layout of the imports a bit, but will change almost all files in that way.
