### PR TITLE
chore: upgrade lint

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: golangci/golangci-lint-action@master
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.37
+          version: v1.41
           args: --issues-exit-code=0 -e SA1019 --timeout 10m
           github-token: ${{ secrets.github_token }}
         if: env.GIT_DIFF

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,7 @@ linters:
     - gocritic
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - gosimple
     - govet


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

### What does this PR does?

<!-- Describe your changes here - ideally you can get that description straight from
your descriptive commit message(s)! -->

Changes the `golint` linter to `revive` and upgrades the lint CI tool version to v1.41.0.  The `revive` linter has a bit more checks and is supported over `golint` in newer versions of `golangci-lint`.

### How to test?

Run `make lint` and see if it works ok.
