### PR TITLE
chore: add supply range param for localnet genesis

### DIFF
--- a/localnet/genesis_template.json
+++ b/localnet/genesis_template.json
@@ -160,7 +160,13 @@
       "campaignCounter": "1",
       "campaignList": [],
       "mainnetAccountList": [],
-      "mainnetVestingAccountList": []
+      "mainnetVestingAccountList": [],
+      "params": {
+        "totalSupplyRange": {
+          "maxTotalSupply": "1000000000000000",
+          "minTotalSupply": "100"
+        }
+      }
     },
     "capability": {
       "index": "1",


### PR DESCRIPTION
Add the new `SupplyRange` param of `campaign` in localnet genesis template with the current default values
