### PR TITLE
fix(`campaign`): properly format `TotalSupplyRange` for param change simulation

### DIFF
--- a/x/campaign/module_simulation.go
+++ b/x/campaign/module_simulation.go
@@ -56,7 +56,10 @@ func (am AppModule) RandomizedParams(r *rand.Rand) []simtypes.ParamChange {
 	campaignParams := sample.CampaignParams()
 	return []simtypes.ParamChange{
 		simulation.NewSimParamChange(types.ModuleName, string(types.ParamStoreKeyTotalSupplyRange), func(r *rand.Rand) string {
-			return fmt.Sprintf("\"%v\"", campaignParams.TotalSupplyRange.String())
+			return fmt.Sprintf(
+				"{\"minTotalSupply\":\"%v\",\"maxTotalSupply\":\"%v\"}",
+				campaignParams.TotalSupplyRange.MinTotalSupply,
+				campaignParams.TotalSupplyRange.MaxTotalSupply)
 		}),
 	}
 }


### PR DESCRIPTION
Closes #553 

### What does this PR does?

Fix a wrong format for `TotalSupplyRange` param in `RandomizedParams` for `campaign/module_simulation.go`. 

### How to test?

Run `starport chain simulate` with the following modifications made to `app/simulation_test.go`:

```golang
func BenchmarkSimulation(b *testing.B) {
	simapp.FlagEnabledValue = true
	simapp.FlagNumBlocksValue = 2000
	simapp.FlagBlockSizeValue = 100
	simapp.FlagCommitValue = true
	simapp.FlagPeriodValue = 10
	simapp.FlagVerboseValue = true
```

Error reported in #553 should not appear now.
