### PR TITLE
feat(`monitoringp`): skip block height 1 in begin-blocker

### DIFF
--- a/x/monitoringc/keeper/msg_server_create_client_test.go
+++ b/x/monitoringc/keeper/msg_server_create_client_test.go
@@ -2,9 +2,10 @@ package keeper_test
 
 import (
 	"encoding/base64"
-	ibctmtypes "github.com/cosmos/ibc-go/v2/modules/light-clients/07-tendermint/types"
 	"testing"
 	"time"
+
+	ibctmtypes "github.com/cosmos/ibc-go/v2/modules/light-clients/07-tendermint/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"

--- a/x/monitoringp/keeper/begin_block.go
+++ b/x/monitoringp/keeper/begin_block.go
@@ -20,6 +20,11 @@ const (
 
 // ReportBlockSignatures gets signatures from blocks and update monitoring info
 func (k Keeper) ReportBlockSignatures(ctx sdk.Context, lastCommit abci.LastCommitInfo, blockHeight int64) {
+	// skip first block because it is not signed
+	if blockHeight == 1 {
+		return
+	}
+
 	// no report if last height is reached
 	lastBlockHeight := k.LastBlockHeight(ctx)
 	if blockHeight > lastBlockHeight {

--- a/x/monitoringp/keeper/begin_block_test.go
+++ b/x/monitoringp/keeper/begin_block_test.go
@@ -80,6 +80,13 @@ func TestKeeper_ReportBlockSignatures(t *testing.T) {
 			expectedMonitoringInfoFound: false,
 		},
 		{
+			name:                        "no monitoring info created because counting skipped if blockHeight == 1",
+			monitoringInfoExist:         false,
+			lastBlockHeight:             1,
+			currentBlockHeight:          1,
+			expectedMonitoringInfoFound: false,
+		},
+		{
 			name:                "lastBlockHeight reached doesn't update an existent monitoring info",
 			monitoringInfoExist: true,
 			inputMonitoringInfo: monitoringInfo(10,
@@ -122,7 +129,7 @@ func TestKeeper_ReportBlockSignatures(t *testing.T) {
 					signed:  true,
 				},
 			),
-			currentBlockHeight:          1,
+			currentBlockHeight:          2,
 			expectedMonitoringInfoFound: true,
 			expectedMonitoringInfo: monitoringInfo(1,
 				signatureCount{
@@ -171,7 +178,7 @@ func TestKeeper_ReportBlockSignatures(t *testing.T) {
 					signed:  true,
 				},
 			),
-			currentBlockHeight:          1,
+			currentBlockHeight:          2,
 			expectedMonitoringInfoFound: true,
 			expectedMonitoringInfo: monitoringInfo(51,
 				signatureCount{

--- a/x/monitoringp/module.go
+++ b/x/monitoringp/module.go
@@ -168,10 +168,6 @@ func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(ctx sdk.Context, bb abci.RequestBeginBlock) {
-	if ctx.BlockHeight() == 1 {
-		return
-	}
-
 	// reports signatures for the block
 	am.keeper.ReportBlockSignatures(ctx, bb.LastCommitInfo, bb.Header.Height)
 

--- a/x/monitoringp/module.go
+++ b/x/monitoringp/module.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"

--- a/x/monitoringp/module.go
+++ b/x/monitoringp/module.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -168,6 +167,10 @@ func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(ctx sdk.Context, bb abci.RequestBeginBlock) {
+	if ctx.BlockHeight() == 1 {
+		return
+	}
+
 	// reports signatures for the block
 	am.keeper.ReportBlockSignatures(ctx, bb.LastCommitInfo, bb.Header.Height)
 


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #564

### What does this PR does?

Skip the `BeginBlock()` function in `x/monitoringp/module.go` when BlockHeight == 1.  I'm not sure how to test this other than recreating the scenario described in the issue.  Any thoughts are welcome.
