### PR TITLE
chore: remove unnecessary sim import code

### DIFF
--- a/x/monitoringc/module_simulation.go
+++ b/x/monitoringc/module_simulation.go
@@ -3,24 +3,13 @@ package monitoringc
 import (
 	"math/rand"
 
-	"github.com/cosmos/cosmos-sdk/baseapp"
-	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 
-	"github.com/tendermint/spn/testutil/sample"
 	monitoringcsimulation "github.com/tendermint/spn/x/monitoringc/simulation"
 	"github.com/tendermint/spn/x/monitoringc/types"
-)
-
-// avoid unused import issue
-var (
-	_ = sample.AccAddress
-	_ = simappparams.StakePerAccount
-	_ = simulation.MsgEntryKind
-	_ = baseapp.Paramspace
 )
 
 const (

--- a/x/monitoringp/module_simulation.go
+++ b/x/monitoringp/module_simulation.go
@@ -3,25 +3,10 @@ package monitoringp
 import (
 	"math/rand"
 
-	"github.com/cosmos/cosmos-sdk/baseapp"
-	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
-	"github.com/cosmos/cosmos-sdk/x/simulation"
-
-	"github.com/tendermint/spn/testutil/sample"
-	monitoringpsimulation "github.com/tendermint/spn/x/monitoringp/simulation"
 	"github.com/tendermint/spn/x/monitoringp/types"
-)
-
-// avoid unused import issue
-var (
-	_ = sample.AccAddress
-	_ = monitoringpsimulation.FindAccount
-	_ = simappparams.StakePerAccount
-	_ = simulation.MsgEntryKind
-	_ = baseapp.Paramspace
 )
 
 const (

--- a/x/participation/module_simulation.go
+++ b/x/participation/module_simulation.go
@@ -3,25 +3,12 @@ package participation
 import (
 	"math/rand"
 
-	"github.com/cosmos/cosmos-sdk/baseapp"
-	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 
-	"github.com/tendermint/spn/testutil/sample"
-	participationsimulation "github.com/tendermint/spn/x/participation/simulation"
 	"github.com/tendermint/spn/x/participation/types"
-)
-
-// avoid unused import issue
-var (
-	_ = sample.AccAddress
-	_ = participationsimulation.FindAccount
-	_ = simappparams.StakePerAccount
-	_ = simulation.MsgEntryKind
-	_ = baseapp.Paramspace
 )
 
 const (

--- a/x/reward/module_simulation.go
+++ b/x/reward/module_simulation.go
@@ -3,25 +3,13 @@ package reward
 import (
 	"math/rand"
 
-	"github.com/cosmos/cosmos-sdk/baseapp"
-	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 
-	"github.com/tendermint/spn/testutil/sample"
 	rewardsimulation "github.com/tendermint/spn/x/reward/simulation"
 	"github.com/tendermint/spn/x/reward/types"
-)
-
-// avoid unused import issue
-var (
-	_ = sample.AccAddress
-	_ = rewardsimulation.FindAccount
-	_ = simappparams.StakePerAccount
-	_ = simulation.MsgEntryKind
-	_ = baseapp.Paramspace
 )
 
 const (


### PR DESCRIPTION
Removes unnecessary imports in the `*/module_simulation.go` files.  The comments say these declarations are supposed to prevent errors, but removing them is completely fine.

Mentioned in #609