### PR TITLE
feat(`monitoring`): add versions for module handshake

### DIFF
--- a/x/monitoringc/module_ibc.go
+++ b/x/monitoringc/module_ibc.go
@@ -20,7 +20,7 @@ func (am AppModule) OnChanOpenInit(
 	ctx sdk.Context,
 	order channeltypes.Order,
 	_ []string,
-	portID string,
+	portID,
 	channelID string,
 	chanCap *capabilitytypes.Capability,
 	_ channeltypes.Counterparty,
@@ -252,14 +252,13 @@ func (am AppModule) OnTimeoutPacket(
 }
 
 // NegotiateAppVersion implements the IBCModule interface
-// TODO(492): implement correct logic
 func (am AppModule) NegotiateAppVersion(
-	ctx sdk.Context,
-	order channeltypes.Order,
-	connectionID string,
-	portID string,
-	counterparty channeltypes.Counterparty,
-	proposedVersion string,
+	_ sdk.Context,
+	_ channeltypes.Order,
+	_,
+	_ string,
+	_ channeltypes.Counterparty,
+	_ string,
 ) (version string, err error) {
 	return types.Version, nil
 }

--- a/x/monitoringc/types/keys.go
+++ b/x/monitoringc/types/keys.go
@@ -22,7 +22,6 @@ const (
 	MemStoreKey = "mem_monitoringc"
 
 	// Version defines the current version the IBC module supports
-	// TODO(492): set correct version
 	Version = "monitoring-1"
 
 	// PortID is the default port id that module binds to

--- a/x/monitoringc/types/keys.go
+++ b/x/monitoringc/types/keys.go
@@ -23,7 +23,7 @@ const (
 
 	// Version defines the current version the IBC module supports
 	// TODO(492): set correct version
-	Version = ""
+	Version = "monitoring-1"
 
 	// PortID is the default port id that module binds to
 	PortID = "monitoring"

--- a/x/monitoringp/module_ibc.go
+++ b/x/monitoringp/module_ibc.go
@@ -20,7 +20,7 @@ func (am AppModule) OnChanOpenInit(
 	_ sdk.Context,
 	_ channeltypes.Order,
 	_ []string,
-	_ string,
+	_,
 	_ string,
 	_ *capabilitytypes.Capability,
 	_ channeltypes.Counterparty,
@@ -37,7 +37,7 @@ func (am AppModule) OnChanOpenTry(
 	portID,
 	channelID string,
 	chanCap *capabilitytypes.Capability,
-	counterparty channeltypes.Counterparty,
+	_ channeltypes.Counterparty,
 	version,
 	counterpartyVersion string,
 ) error {
@@ -259,11 +259,10 @@ func (am AppModule) OnTimeoutPacket(
 }
 
 // NegotiateAppVersion implements the IBCModule interface
-// TODO(492): implement correct logic
 func (am AppModule) NegotiateAppVersion(
 	_ sdk.Context,
 	_ channeltypes.Order,
-	_ string,
+	_ ,
 	_ string,
 	_ channeltypes.Counterparty,
 	_ string,

--- a/x/monitoringp/module_ibc.go
+++ b/x/monitoringp/module_ibc.go
@@ -262,7 +262,7 @@ func (am AppModule) OnTimeoutPacket(
 func (am AppModule) NegotiateAppVersion(
 	_ sdk.Context,
 	_ channeltypes.Order,
-	_ ,
+	_,
 	_ string,
 	_ channeltypes.Counterparty,
 	_ string,

--- a/x/monitoringp/types/keys.go
+++ b/x/monitoringp/types/keys.go
@@ -20,7 +20,6 @@ const (
 	MemStoreKey = "mem_monitoringp"
 
 	// Version defines the current version the IBC module supports
-	// TODO(492): set correct version
 	Version = "monitoring-1"
 
 	// PortID is the default port id that module binds to

--- a/x/monitoringp/types/keys.go
+++ b/x/monitoringp/types/keys.go
@@ -21,7 +21,7 @@ const (
 
 	// Version defines the current version the IBC module supports
 	// TODO(492): set correct version
-	Version = ""
+	Version = "monitoring-1"
 
 	// PortID is the default port id that module binds to
 	PortID = "monitoring"


### PR DESCRIPTION
Set `monitoring-1` for the version of the module.

Relayer connection works from Hermes `0.12.0` https://github.com/informalsystems/ibc-rs/releases/tag/v0.12.0
(there was an issue with custom version in previous releases)