### PR TITLE
fix(`simulation`): add fee checks

### DIFF
--- a/x/campaign/simulation/simulation.go
+++ b/x/campaign/simulation/simulation.go
@@ -55,6 +55,35 @@ func deliverSimTx(
 	return simulation.GenAndDeliverTxWithRandFees(txCtx)
 }
 
+// deliverSimTx delivers the tx for simulation from the provided message
+func deliverSimTxCustomFee(
+	r *rand.Rand,
+	app *baseapp.BaseApp,
+	ctx sdk.Context,
+	ak types.AccountKeeper,
+	bk types.BankKeeper,
+	simAccount simtypes.Account,
+	msg TypedMsg,
+	coinsSpent sdk.Coins,
+	customFee sdk.Coins,
+) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+	txCtx := simulation.OperationInput{
+		R:               r,
+		App:             app,
+		TxGen:           simappparams.MakeTestEncodingConfig().TxConfig,
+		Cdc:             nil,
+		Msg:             msg,
+		MsgType:         msg.Type(),
+		Context:         ctx,
+		SimAccount:      simAccount,
+		AccountKeeper:   ak,
+		Bankkeeper:      bk,
+		ModuleName:      types.ModuleName,
+		CoinsSpentInMsg: coinsSpent,
+	}
+	return simulation.GenAndDeliverTx(txCtx, customFee)
+}
+
 // GetCoordSimAccount finds an account associated with a coordinator profile from simulation accounts
 func GetCoordSimAccount(
 	r *rand.Rand,
@@ -267,7 +296,16 @@ func SimulateMsgCreateCampaign(
 
 		// skip if account cannot cover creation fee
 		creationFee := k.CampaignCreationFee(ctx)
-		if !creationFee.Empty() && !bk.SpendableCoins(ctx, simAccount.Address).IsAllGTE(creationFee) {
+		customFee, err := simtypes.RandomFees(r, ctx, creationFee)
+		if err != nil {
+			return simtypes.NoOpMsg(
+					types.ModuleName,
+					types.TypeMsgCreateCampaign,
+					"skip campaign creation"),
+				nil,
+				nil
+		}
+		if !creationFee.Empty() && !bk.SpendableCoins(ctx, simAccount.Address).IsAllGTE(creationFee.Add(customFee...)) {
 			return simtypes.NoOpMsg(types.ModuleName, types.TypeMsgCreateCampaign, "skip campaign creation"), nil, nil
 		}
 
@@ -278,7 +316,7 @@ func SimulateMsgCreateCampaign(
 			sample.Metadata(20),
 		)
 
-		return deliverSimTx(r, app, ctx, ak, bk, simAccount, msg, sdk.NewCoins())
+		return deliverSimTxCustomFee(r, app, ctx, ak, bk, simAccount, msg, sdk.NewCoins(), customFee)
 	}
 }
 

--- a/x/campaign/simulation/simulation.go
+++ b/x/campaign/simulation/simulation.go
@@ -298,12 +298,9 @@ func SimulateMsgCreateCampaign(
 		creationFee := k.CampaignCreationFee(ctx)
 		customFee, err := simtypes.RandomFees(r, ctx, creationFee)
 		if err != nil {
-			return simtypes.NoOpMsg(
-					types.ModuleName,
-					types.TypeMsgCreateCampaign,
-					"skip campaign creation"),
+			return simtypes.OperationMsg{},
 				nil,
-				nil
+				err
 		}
 		if !creationFee.Empty() && !bk.SpendableCoins(ctx, simAccount.Address).IsAllGTE(creationFee.Add(customFee...)) {
 			return simtypes.NoOpMsg(types.ModuleName, types.TypeMsgCreateCampaign, "skip campaign creation"), nil, nil

--- a/x/launch/simulation/simulation.go
+++ b/x/launch/simulation/simulation.go
@@ -34,11 +34,23 @@ func SimulateMsgCreateChain(ak types.AccountKeeper, bk types.BankKeeper, k keepe
 			// No message if no coordinator
 			return simtypes.NoOpMsg(types.ModuleName, types.TypeMsgCreateChain, "skip create a new chain"), nil, nil
 		}
+
 		// skip if account cannot cover creation fee
 		creationFee := k.ChainCreationFee(ctx)
-		if !creationFee.Empty() && !bk.SpendableCoins(ctx, simAccount.Address).IsAllGTE(creationFee) {
-			return simtypes.NoOpMsg(types.ModuleName, types.TypeMsgCreateChain, "skip campaign creation"), nil, nil
+		customFee, err := simtypes.RandomFees(r, ctx, creationFee)
+		if err != nil {
+			return simtypes.NoOpMsg(
+					types.ModuleName,
+					types.TypeMsgCreateChain,
+					"skip chain creation"),
+				nil,
+				nil
 		}
+
+		if !creationFee.Empty() && !bk.SpendableCoins(ctx, simAccount.Address).IsAllGTE(creationFee.Add(customFee...)) {
+			return simtypes.NoOpMsg(types.ModuleName, types.TypeMsgCreateChain, "skip chain creation"), nil, nil
+		}
+
 		msg := sample.MsgCreateChain(
 			simAccount.Address.String(),
 			"",
@@ -59,7 +71,7 @@ func SimulateMsgCreateChain(ak types.AccountKeeper, bk types.BankKeeper, k keepe
 			ModuleName:      types.ModuleName,
 			CoinsSpentInMsg: sdk.NewCoins(),
 		}
-		return simulation.GenAndDeliverTxWithRandFees(txCtx)
+		return simulation.GenAndDeliverTx(txCtx, customFee)
 	}
 }
 

--- a/x/launch/simulation/simulation.go
+++ b/x/launch/simulation/simulation.go
@@ -39,12 +39,11 @@ func SimulateMsgCreateChain(ak types.AccountKeeper, bk types.BankKeeper, k keepe
 		creationFee := k.ChainCreationFee(ctx)
 		customFee, err := simtypes.RandomFees(r, ctx, creationFee)
 		if err != nil {
-			return simtypes.NoOpMsg(
-					types.ModuleName,
-					types.TypeMsgCreateChain,
-					"skip chain creation"),
-				nil,
-				nil
+			if err != nil {
+				return simtypes.OperationMsg{},
+					nil,
+					err
+			}
 		}
 
 		if !creationFee.Empty() && !bk.SpendableCoins(ctx, simAccount.Address).IsAllGTE(creationFee.Add(customFee...)) {


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #652

Add a balance check to `SimulateCreateCampaign` and `SimulateCreateChain` that also includes checking the account balance is enough to cover the creation fee as well as a pre-calculated random gas fee.

`make test-sim-profile` does not run into the issue described in the attached issue, but there are still simulation issues to be dug into.