### PR TITLE
test(`launch`): CheckAccount test

### DIFF
--- a/x/campaign/client/cli/query_campaign_summary.go
+++ b/x/campaign/client/cli/query_campaign_summary.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/spn/x/campaign/types"
 )
 

--- a/x/campaign/simulation/simulation.go
+++ b/x/campaign/simulation/simulation.go
@@ -1,13 +1,14 @@
 package simulation
 
 import (
+	"math/rand"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
-	"math/rand"
 
 	spntypes "github.com/tendermint/spn/pkg/types"
 	"github.com/tendermint/spn/testutil/sample"

--- a/x/campaign/types/expected_keepers.go
+++ b/x/campaign/types/expected_keepers.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
 	profiletypes "github.com/tendermint/spn/x/profile/types"
 )
 


### PR DESCRIPTION
Add a new test for `keeper.CheckAccount()`.  I was investigating these functions for our simulation issues and realized we did not have a test for this function.