### PR TITLE
fix(`simulation`): remove non-deterministic sim behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ SIM_COMMIT ?= true
 test-sim-nondeterminism:
 	@echo "Running non-determinism test..."
 	@VERSION=$(VERSION) go test -mod=readonly $(SIMAPP) -run TestAppStateDeterminism -Enabled=true \
-		-NumBlocks=10 -BlockSize=10 -Commit=true -Period=0 -v -timeout 24h
+		-NumBlocks=10 -BlockSize=100 -Commit=true -Period=0 -v -timeout 24h
 
 ## test-sim-ci: Run lightweight simulation for CI pipeline
 test-sim-ci:

--- a/x/launch/simulation/simulation.go
+++ b/x/launch/simulation/simulation.go
@@ -212,14 +212,26 @@ func SimulateMsgRequestRemoveAccount(ak types.AccountKeeper, bk types.BankKeeper
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
-		accsChain := make(map[string]uint64)
+		type accChain struct {
+			address  string
+			launchID uint64
+		}
+
+		accChainList := make([]accChain, 0)
+
 		genAccs := k.GetAllGenesisAccount(ctx)
 		for _, acc := range genAccs {
-			accsChain[acc.Address] = acc.LaunchID
+			accChainList = append(accChainList, accChain{
+				address:  acc.Address,
+				launchID: acc.LaunchID,
+			})
 		}
 		vestAccs := k.GetAllVestingAccount(ctx)
 		for _, acc := range vestAccs {
-			accsChain[acc.Address] = acc.LaunchID
+			accChainList = append(accChainList, accChain{
+				address:  acc.Address,
+				launchID: acc.LaunchID,
+			})
 		}
 
 		var (
@@ -228,18 +240,18 @@ func SimulateMsgRequestRemoveAccount(ak types.AccountKeeper, bk types.BankKeeper
 			accChainID uint64
 		)
 		found := false
-		for acc, chainID := range accsChain {
-			if IsLaunchTriggeredChain(ctx, k, chainID) {
+		for _, accChain := range accChainList {
+			if IsLaunchTriggeredChain(ctx, k, accChain.launchID) {
 				continue
 			}
-			// get coordinator account for removal
+			// get coordinator account
 			var err error
-			simAccount, err = FindChainCoordinatorAccount(ctx, k, accs, chainID)
+			simAccount, err = FindChainCoordinatorAccount(ctx, k, accs, accChain.launchID)
 			if err != nil {
 				continue
 			}
-			accAddr = acc
-			accChainID = chainID
+			accAddr = accChain.address
+			accChainID = accChain.launchID
 			found = true
 			break
 		}
@@ -247,17 +259,18 @@ func SimulateMsgRequestRemoveAccount(ak types.AccountKeeper, bk types.BankKeeper
 			return simtypes.NoOpMsg(types.ModuleName, types.TypeMsgRequestRemoveAccount, "genesis account not found"), nil, nil
 		}
 
-		msg := sample.MsgRequestRemoveAccount(
+		msg := types.NewMsgRequestRemoveAccount(
 			simAccount.Address.String(),
-			accAddr,
 			accChainID,
+			accAddr,
 		)
+
 		txCtx := simulation.OperationInput{
 			R:               r,
 			App:             app,
 			TxGen:           simappparams.MakeTestEncodingConfig().TxConfig,
 			Cdc:             nil,
-			Msg:             &msg,
+			Msg:             msg,
 			MsgType:         msg.Type(),
 			Context:         ctx,
 			SimAccount:      simAccount,


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #659

### What does this PR does?

Removes the usage of a `map` in the setup code for simulating `MsgRequestRemoveAccount`.  The traversal of maps in range-based for loops is non-deterministic, so this was causing the issue.

To verify, run `make test-sim-nondeterminism` on your local machine.