### PR TITLE
fix(`campaign`): fix sample genesis with inconsistent state

### DIFF
--- a/testutil/sample/campaign.go
+++ b/testutil/sample/campaign.go
@@ -112,15 +112,6 @@ func CampaignGenesisState(r *rand.Rand) campaign.GenesisState {
 				Chains:     []uint64{0, 1},
 			},
 		},
-		MainnetVestingAccountList: []campaign.MainnetVestingAccount{
-			MainnetVestingAccount(r, 0, Address(r)),
-			MainnetVestingAccount(r, 0, Address(r)),
-			MainnetVestingAccount(r, 1, Address(r)),
-		},
-		MainnetAccountList: []campaign.MainnetAccount{
-			MainnetAccount(r, 0, Address(r)),
-			MainnetAccount(r, 1, Address(r)),
-		},
 		TotalShares: spntypes.TotalShareNumber,
 		Params:      CampaignParams(r),
 	}


### PR DESCRIPTION
`CampaignGenesisState` from `sample` contains campaigns initialized with empty allocated shares and mainnet accounts containing shares.

This genesis state was inconsistent because the sum of shares allocated for accounts must be tracked by the `AllocatedShares` value of the campaign

This PR removes the accounts for a quick fix. A further change can include adding accounts with the allocated correctly tracked for better entropy 
