### PR TITLE
refactor(`launch`): improve invariant

### DIFF
--- a/x/launch/keeper/invariants.go
+++ b/x/launch/keeper/invariants.go
@@ -9,15 +9,15 @@ import (
 )
 
 const (
-	zeroLaunchTimestampRoute = "zero-launch-timestamp"
-	duplicatedAccountRoute   = "duplicated-account"
-	unknownRequestTypeRoute  = "unknown-request-type"
+	invalidChainRoute       = "invalid-chain"
+	duplicatedAccountRoute  = "duplicated-account"
+	unknownRequestTypeRoute = "unknown-request-type"
 )
 
 // RegisterInvariants registers all module invariants
 func RegisterInvariants(ir sdk.InvariantRegistry, k Keeper) {
-	ir.RegisterRoute(types.ModuleName, zeroLaunchTimestampRoute,
-		ZeroLaunchTimestampInvariant(k))
+	ir.RegisterRoute(types.ModuleName, invalidChainRoute,
+		InvalidChainInvariant(k))
 	ir.RegisterRoute(types.ModuleName, duplicatedAccountRoute,
 		DuplicatedAccountInvariant(k))
 	ir.RegisterRoute(types.ModuleName, unknownRequestTypeRoute,
@@ -35,20 +35,20 @@ func AllInvariants(k Keeper) sdk.Invariant {
 		if stop {
 			return res, stop
 		}
-		return ZeroLaunchTimestampInvariant(k)(ctx)
+		return InvalidChainInvariant(k)(ctx)
 	}
 }
 
-// ZeroLaunchTimestampInvariant invariant that checks if the
-// `LaunchTimestamp` is zero
-func ZeroLaunchTimestampInvariant(k Keeper) sdk.Invariant {
+// InvalidChainInvariant invariant that checks all chain in the store are valid
+func InvalidChainInvariant(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
-		all := k.GetAllChain(ctx)
-		for _, chain := range all {
-			if chain.LaunchTimestamp == 0 {
+		chains := k.GetAllChain(ctx)
+		for _, chain := range chains {
+			err := chain.Validate()
+			if err != nil {
 				return sdk.FormatInvariant(
-					types.ModuleName, zeroLaunchTimestampRoute,
-					"LaunchTimestamp is not set while LaunchTriggered is set",
+					types.ModuleName, invalidChainRoute,
+					fmt.Sprintf("chain %d is invalid: %s", chain.LaunchID, err.Error()),
 				), true
 			}
 		}

--- a/x/launch/keeper/invariants_test.go
+++ b/x/launch/keeper/invariants_test.go
@@ -16,35 +16,34 @@ func TestDuplicatedAccountInvariant(t *testing.T) {
 	t.Run("valid case", func(t *testing.T) {
 		tk.LaunchKeeper.SetVestingAccount(ctx, sample.VestingAccount(r, 0, sample.Address(r)))
 		tk.LaunchKeeper.SetGenesisAccount(ctx, sample.GenesisAccount(r, 0, sample.Address(r)))
-		_, isValid := keeper.DuplicatedAccountInvariant(*tk.LaunchKeeper)(ctx)
-		require.Equal(t, false, isValid)
+		msg, broken := keeper.DuplicatedAccountInvariant(*tk.LaunchKeeper)(ctx)
+		require.False(t, broken, msg)
 	})
 
 	t.Run("invalid case", func(t *testing.T) {
 		addr := sample.Address(r)
 		tk.LaunchKeeper.SetVestingAccount(ctx, sample.VestingAccount(r, 0, addr))
 		tk.LaunchKeeper.SetGenesisAccount(ctx, sample.GenesisAccount(r, 0, addr))
-		_, isValid := keeper.DuplicatedAccountInvariant(*tk.LaunchKeeper)(ctx)
-		require.Equal(t, true, isValid)
+		msg, broken := keeper.DuplicatedAccountInvariant(*tk.LaunchKeeper)(ctx)
+		require.True(t, broken, msg)
 	})
 }
 
-func TestZeroLaunchTimestampInvariant(t *testing.T) {
+func TestInvalidChainInvariant(t *testing.T) {
 	ctx, tk, _ := testkeeper.NewTestSetup(t)
 	t.Run("valid case", func(t *testing.T) {
 		chain := sample.Chain(r, 0, 0)
-		chain.LaunchTimestamp = 1000
 		chain.LaunchID = tk.LaunchKeeper.AppendChain(ctx, chain)
-		_, isValid := keeper.ZeroLaunchTimestampInvariant(*tk.LaunchKeeper)(ctx)
-		require.Equal(t, false, isValid)
+		msg, broken := keeper.InvalidChainInvariant(*tk.LaunchKeeper)(ctx)
+		require.False(t, broken, msg)
 	})
 
 	t.Run("invalid case", func(t *testing.T) {
 		chain := sample.Chain(r, 0, 0)
-		chain.LaunchTimestamp = 0
+		chain.LaunchTriggered = true
 		chain.LaunchID = tk.LaunchKeeper.AppendChain(ctx, chain)
-		_, isValid := keeper.ZeroLaunchTimestampInvariant(*tk.LaunchKeeper)(ctx)
-		require.Equal(t, true, isValid)
+		msg, broken := keeper.InvalidChainInvariant(*tk.LaunchKeeper)(ctx)
+		require.True(t, broken, msg)
 	})
 }
 
@@ -52,15 +51,15 @@ func TestUnknownRequestTypeInvariant(t *testing.T) {
 	ctx, tk, _ := testkeeper.NewTestSetup(t)
 	t.Run("valid case", func(t *testing.T) {
 		tk.LaunchKeeper.AppendRequest(ctx, sample.Request(r, 0, sample.Address(r)))
-		_, isValid := keeper.UnknownRequestTypeInvariant(*tk.LaunchKeeper)(ctx)
-		require.Equal(t, false, isValid)
+		msg, broken := keeper.UnknownRequestTypeInvariant(*tk.LaunchKeeper)(ctx)
+		require.False(t, broken, msg)
 	})
 
 	t.Run("invalid case", func(t *testing.T) {
 		tk.LaunchKeeper.AppendRequest(ctx, sample.RequestWithContent(r, 0,
 			sample.GenesisAccountContent(r, 0, "invalid"),
 		))
-		_, isValid := keeper.UnknownRequestTypeInvariant(*tk.LaunchKeeper)(ctx)
-		require.Equal(t, true, isValid)
+		msg, broken := keeper.UnknownRequestTypeInvariant(*tk.LaunchKeeper)(ctx)
+		require.True(t, broken, msg)
 	})
 }


### PR DESCRIPTION
Replace the launch timestamp invariant with an invariant that checks all chains are valid
