### PR TITLE
refactor(`keeper/msg_`): set invalid bech32 address error as critical error

### DIFF
--- a/x/campaign/keeper/msg_create_campaign.go
+++ b/x/campaign/keeper/msg_create_campaign.go
@@ -35,7 +35,7 @@ func (k msgServer) CreateCampaign(goCtx context.Context, msg *types.MsgCreateCam
 	if !creationFee.Empty() {
 		coordAddr, err := sdk.AccAddressFromBech32(msg.Coordinator)
 		if err != nil {
-			return nil, err
+			return nil, spnerrors.Criticalf("invalid coordinator bech32 address %s", err.Error())
 		}
 		if err = k.distrKeeper.FundCommunityPool(ctx, creationFee, coordAddr); err != nil {
 			return nil, err

--- a/x/launch/keeper/msg_create_chain.go
+++ b/x/launch/keeper/msg_create_chain.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
+	spnerrors "github.com/tendermint/spn/pkg/errors"
 	"github.com/tendermint/spn/x/launch/types"
 )
 
@@ -42,7 +43,7 @@ func (k msgServer) CreateChain(goCtx context.Context, msg *types.MsgCreateChain)
 	if !creationFee.Empty() {
 		coordAddr, err := sdk.AccAddressFromBech32(msg.Coordinator)
 		if err != nil {
-			return nil, err
+			return nil, spnerrors.Criticalf("invalid coordinator bech32 address %s", err.Error())
 		}
 		if err = k.distrKeeper.FundCommunityPool(ctx, creationFee, coordAddr); err != nil {
 			return nil, err


### PR DESCRIPTION
Valid bech32 address for message signer is part of the condition for message static validity. Therefore, such an error in the handler should be considered as a critical error