### PR TITLE
fix(`launch`): do not set `campaignID` in `msgEditChain` simulation if chain already has a campaign

### DIFF
--- a/x/launch/simulation/simulation.go
+++ b/x/launch/simulation/simulation.go
@@ -92,6 +92,10 @@ func SimulateMsgEditChain(ak types.AccountKeeper, bk types.BankKeeper, k keeper.
 
 		modify := r.Intn(100) < 50
 		setCampaignID := r.Intn(100) < 50
+		// do not set campaignID if already set
+		if chain.HasCampaign {
+			setCampaignID = false
+		}
 		// ensure there is always a value to edit
 		if !modify && !setCampaignID {
 			modify = true


### PR DESCRIPTION
Closes #662 

### What does this PR does?

This PR adds a check in the simulation of `msgEditChain` that only modifies `metadata` if the randomly-selected chain already has an associated campaign