### PR TITLE
chore: bump fundraising module version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/cast v1.4.1
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
-	github.com/tendermint/fundraising v0.1.2-0.20220406040803-d65fe31abb77
+	github.com/tendermint/fundraising v0.2.0
 	github.com/tendermint/starport v0.19.5
 	github.com/tendermint/tendermint v0.34.16
 	github.com/tendermint/tm-db v0.6.6

--- a/go.sum
+++ b/go.sum
@@ -1502,8 +1502,8 @@ github.com/tendermint/btcd v0.1.1/go.mod h1:DC6/m53jtQzr/NFmMNEu0rxf18/ktVoVtMrn
 github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15 h1:hqAk8riJvK4RMWx1aInLzndwxKalgi5rTqgfXxOxbEI=
 github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15/go.mod h1:z4YtwM70uOnk8h0pjJYlj3zdYwi9l03By6iAIF5j/Pk=
 github.com/tendermint/flutter/v2 v2.0.3/go.mod h1:hnaVhWhzv2Od1LqZFWrRKwiOHeMonsB9EIWP0AGMPw0=
-github.com/tendermint/fundraising v0.1.2-0.20220406040803-d65fe31abb77 h1:2iAVq2gPupcLUamsSw783lj30eaUpF4CV6HHdMR/LE8=
-github.com/tendermint/fundraising v0.1.2-0.20220406040803-d65fe31abb77/go.mod h1:AoOF/njoU8FZMZTngspweCClg+3ANI0aRswe0FaUQsE=
+github.com/tendermint/fundraising v0.2.0 h1:V6N7u/oWXjQZEbXXk34uAfijYnYQFZrZGA39e03UFz8=
+github.com/tendermint/fundraising v0.2.0/go.mod h1:AoOF/njoU8FZMZTngspweCClg+3ANI0aRswe0FaUQsE=
 github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2lyGa2E=
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tendermint/spm v0.1.8/go.mod h1:iHgfQ5YOI6ONc9E7ugGQolVdfSMHpeXfZ/OpXuN/42Q=


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #<issue number>. _in case of a bug fix, this should point to a bug or any other related issue(s)_

### What does this PR does?

- Bumps the `fundraising` module to `v0.2.0`.  Previously we were using a cherry-picked commit.
