### PR TITLE
test: increase code coverage for `campaign`, `participation` and `profile`

### DIFF
--- a/testutil/sample/campaign.go
+++ b/testutil/sample/campaign.go
@@ -120,17 +120,22 @@ func CampaignGenesisState(r *rand.Rand) campaign.GenesisState {
 // CampaignGenesisStateWithAccounts returns a sample genesis state for the campaign module that includes accounts
 func CampaignGenesisStateWithAccounts(r *rand.Rand) campaign.GenesisState {
 	genState := CampaignGenesisState(r)
-	genState.MainnetAccountList = []campaign.MainnetAccount{
-		MainnetAccount(r, 0, Address(r)),
-		MainnetAccount(r, 0, Address(r)),
-		MainnetAccount(r, 1, Address(r)),
-		MainnetAccount(r, 1, Address(r)),
-	}
-	genState.MainnetVestingAccountList = []campaign.MainnetVestingAccount{
-		MainnetVestingAccount(r, 0, Address(r)),
-		MainnetVestingAccount(r, 0, Address(r)),
-		MainnetVestingAccount(r, 1, Address(r)),
-		MainnetVestingAccount(r, 1, Address(r)),
+	genState.MainnetAccountList = make([]campaign.MainnetAccount, 0)
+	genState.MainnetVestingAccountList = make([]campaign.MainnetVestingAccount, 0)
+
+	for i, c := range genState.CampaignList {
+		for j := 0; j < 5; j++ {
+			mainnetAccount := MainnetAccount(r, c.CampaignID, Address(r))
+			mainnetVestingAccount := MainnetVestingAccount(r, c.CampaignID, Address(r))
+			genState.MainnetAccountList = append(genState.MainnetAccountList, mainnetAccount)
+			genState.MainnetVestingAccountList = append(genState.MainnetVestingAccountList, mainnetVestingAccount)
+
+			// increase campaign allocated shares accordingly
+			c.AllocatedShares = campaign.IncreaseShares(c.AllocatedShares, mainnetAccount.Shares)
+			shares, _ := mainnetVestingAccount.GetTotalShares()
+			c.AllocatedShares = campaign.IncreaseShares(c.AllocatedShares, shares)
+		}
+		genState.CampaignList[i] = c
 	}
 
 	return genState

--- a/testutil/sample/campaign.go
+++ b/testutil/sample/campaign.go
@@ -116,3 +116,36 @@ func CampaignGenesisState(r *rand.Rand) campaign.GenesisState {
 		Params:      CampaignParams(r),
 	}
 }
+
+// CampaignGenesisStateWithAccounts returns a sample genesis state for the campaign module that includes accounts
+func CampaignGenesisStateWithAccounts(r *rand.Rand) campaign.GenesisState {
+	campaign1, campaign2 := Campaign(r, 0), Campaign(r, 1)
+
+	return campaign.GenesisState{
+		CampaignList: []campaign.Campaign{
+			campaign1,
+			campaign2,
+		},
+		CampaignCounter: 2,
+		CampaignChainsList: []campaign.CampaignChains{
+			{
+				CampaignID: 0,
+				Chains:     []uint64{0, 1},
+			},
+		},
+		MainnetAccountList: []campaign.MainnetAccount{
+			MainnetAccount(r, 0, Address(r)),
+			MainnetAccount(r, 0, Address(r)),
+			MainnetAccount(r, 1, Address(r)),
+			MainnetAccount(r, 1, Address(r)),
+		},
+		MainnetVestingAccountList: []campaign.MainnetVestingAccount{
+			MainnetVestingAccount(r, 0, Address(r)),
+			MainnetVestingAccount(r, 0, Address(r)),
+			MainnetVestingAccount(r, 1, Address(r)),
+			MainnetVestingAccount(r, 1, Address(r)),
+		},
+		TotalShares: spntypes.TotalShareNumber,
+		Params:      CampaignParams(r),
+	}
+}

--- a/testutil/sample/campaign.go
+++ b/testutil/sample/campaign.go
@@ -119,33 +119,19 @@ func CampaignGenesisState(r *rand.Rand) campaign.GenesisState {
 
 // CampaignGenesisStateWithAccounts returns a sample genesis state for the campaign module that includes accounts
 func CampaignGenesisStateWithAccounts(r *rand.Rand) campaign.GenesisState {
-	campaign1, campaign2 := Campaign(r, 0), Campaign(r, 1)
-
-	return campaign.GenesisState{
-		CampaignList: []campaign.Campaign{
-			campaign1,
-			campaign2,
-		},
-		CampaignCounter: 2,
-		CampaignChainsList: []campaign.CampaignChains{
-			{
-				CampaignID: 0,
-				Chains:     []uint64{0, 1},
-			},
-		},
-		MainnetAccountList: []campaign.MainnetAccount{
-			MainnetAccount(r, 0, Address(r)),
-			MainnetAccount(r, 0, Address(r)),
-			MainnetAccount(r, 1, Address(r)),
-			MainnetAccount(r, 1, Address(r)),
-		},
-		MainnetVestingAccountList: []campaign.MainnetVestingAccount{
-			MainnetVestingAccount(r, 0, Address(r)),
-			MainnetVestingAccount(r, 0, Address(r)),
-			MainnetVestingAccount(r, 1, Address(r)),
-			MainnetVestingAccount(r, 1, Address(r)),
-		},
-		TotalShares: spntypes.TotalShareNumber,
-		Params:      CampaignParams(r),
+	genState := CampaignGenesisState(r)
+	genState.MainnetAccountList = []campaign.MainnetAccount{
+		MainnetAccount(r, 0, Address(r)),
+		MainnetAccount(r, 0, Address(r)),
+		MainnetAccount(r, 1, Address(r)),
+		MainnetAccount(r, 1, Address(r)),
 	}
+	genState.MainnetVestingAccountList = []campaign.MainnetVestingAccount{
+		MainnetVestingAccount(r, 0, Address(r)),
+		MainnetVestingAccount(r, 0, Address(r)),
+		MainnetVestingAccount(r, 1, Address(r)),
+		MainnetVestingAccount(r, 1, Address(r)),
+	}
+
+	return genState
 }

--- a/testutil/sample/participation.go
+++ b/testutil/sample/participation.go
@@ -40,11 +40,36 @@ func ParticipationParams(r *rand.Rand) participation.Params {
 	return participation.NewParams(allocationPrice, tiers, registrationPeriod, withdrawalDelay)
 }
 
-// ParticipationGenesisState  returns a sample genesis state for the participation module
+// ParticipationGenesisState returns a sample genesis state for the participation module
 func ParticipationGenesisState(r *rand.Rand) participation.GenesisState {
 	return participation.GenesisState{
 		Params:                     ParticipationParams(r),
 		UsedAllocationsList:        []participation.UsedAllocations{},
 		AuctionUsedAllocationsList: []participation.AuctionUsedAllocations{},
 	}
+}
+
+// ParticipationGenesisStateWithAllocations returns a sample genesis state for the participation module with some
+// sample allocations
+func ParticipationGenesisStateWithAllocations(r *rand.Rand) participation.GenesisState {
+	genState := ParticipationGenesisState(r)
+	for i := 0; i < 10; i++ {
+		addr := Address(r)
+		usedAllocs := participation.UsedAllocations{
+			Address:        addr,
+			NumAllocations: 0,
+		}
+		for j := 0; j < 3; j++ {
+			auctionUsedAllocs := participation.AuctionUsedAllocations{
+				Address:        addr,
+				AuctionID:      uint64(j),
+				NumAllocations: uint64(r.Int63n(5) + 1),
+				Withdrawn:      false,
+			}
+			genState.AuctionUsedAllocationsList = append(genState.AuctionUsedAllocationsList, auctionUsedAllocs)
+			usedAllocs.NumAllocations += auctionUsedAllocs.NumAllocations
+		}
+		genState.UsedAllocationsList = append(genState.UsedAllocationsList, usedAllocs)
+	}
+	return genState
 }

--- a/testutil/sample/profile.go
+++ b/testutil/sample/profile.go
@@ -67,6 +67,7 @@ func ProfileGenesisState(r *rand.Rand, addresses ...string) profile.GenesisState
 	for len(addresses) < 7 {
 		addresses = append(addresses, Address(r))
 	}
+	operatorAddresses := []string{OperatorAddress(r), OperatorAddress(r)}
 	return profile.GenesisState{
 		CoordinatorList: []profile.Coordinator{
 			{
@@ -125,12 +126,24 @@ func ProfileGenesisState(r *rand.Rand, addresses ...string) profile.GenesisState
 		CoordinatorCounter: 5,
 		ValidatorList: []profile.Validator{
 			{
-				Address:     addresses[5],
-				Description: ValidatorDescription(String(r, 10)),
+				Address:           addresses[5],
+				Description:       ValidatorDescription(String(r, 10)),
+				OperatorAddresses: []string{operatorAddresses[0]},
 			},
 			{
-				Address:     addresses[6],
-				Description: ValidatorDescription(String(r, 10)),
+				Address:           addresses[6],
+				Description:       ValidatorDescription(String(r, 10)),
+				OperatorAddresses: []string{operatorAddresses[1]},
+			},
+		},
+		ValidatorByOperatorAddressList: []profile.ValidatorByOperatorAddress{
+			{
+				OperatorAddress:  operatorAddresses[0],
+				ValidatorAddress: addresses[5],
+			},
+			{
+				OperatorAddress:  operatorAddresses[1],
+				ValidatorAddress: addresses[6],
 			},
 		},
 	}

--- a/x/campaign/genesis_test.go
+++ b/x/campaign/genesis_test.go
@@ -20,7 +20,7 @@ func TestGenesis(t *testing.T) {
 	ctx, tk, _ := testkeeper.NewTestSetup(t)
 	r := sample.Rand()
 
-	genesisState := sample.CampaignGenesisState(r)
+	genesisState := sample.CampaignGenesisStateWithAccounts(r)
 	campaign.InitGenesis(ctx, *tk.CampaignKeeper, genesisState)
 	got := *campaign.ExportGenesis(ctx, *tk.CampaignKeeper)
 

--- a/x/campaign/keeper/invariants.go
+++ b/x/campaign/keeper/invariants.go
@@ -113,14 +113,6 @@ func CampaignSharesInvariant(k Keeper) sdk.Invariant {
 			campaignID := campaign.CampaignID
 			expectedAllocatedSharesShares := accountSharesByCampaign[campaignID]
 
-			campaign, found := k.GetCampaign(ctx, campaignID)
-			if !found {
-				return sdk.FormatInvariant(
-					types.ModuleName, campaignSharesRoute,
-					fmt.Sprintf("%s: %d", types.ErrCampaignNotFound, campaignID),
-				), true
-			}
-
 			// read existing denoms from allocated shares of the campaign to check possible minted vouchers
 			allocated, err := types.SharesToVouchers(campaign.GetAllocatedShares(), campaignID)
 			if err != nil {
@@ -140,14 +132,9 @@ func CampaignSharesInvariant(k Keeper) sdk.Invariant {
 				vouchers = vouchers.Add(voucherSupply)
 			}
 
-			// convert to shares and add to the campaign shares
-			vShares, err := types.VouchersToShares(vouchers, campaignID)
-			if err != nil {
-				return sdk.FormatInvariant(
-					types.ModuleName, campaignSharesRoute,
-					"fail to convert vouchers to shares",
-				), true
-			}
+			// convert to shares and add to the campaign shares - since we are converting shares to vouchers earlier,
+			// this conversion back to shares will never fail by design, thus we can ignore the error
+			vShares, _ := types.VouchersToShares(vouchers, campaignID)
 			expectedAllocatedSharesShares = types.IncreaseShares(expectedAllocatedSharesShares, vShares)
 
 			if !types.IsEqualShares(expectedAllocatedSharesShares, campaign.GetAllocatedShares()) {

--- a/x/campaign/keeper/invariants.go
+++ b/x/campaign/keeper/invariants.go
@@ -31,7 +31,11 @@ func AllInvariants(k Keeper) sdk.Invariant {
 		if stop {
 			return res, stop
 		}
-		return VestingAccountWithoutCampaignInvariant(k)(ctx)
+		res, stop = VestingAccountWithoutCampaignInvariant(k)(ctx)
+		if stop {
+			return res, stop
+		}
+		return CampaignSharesInvariant(k)(ctx)
 	}
 }
 

--- a/x/campaign/keeper/invariants.go
+++ b/x/campaign/keeper/invariants.go
@@ -138,7 +138,7 @@ func CampaignSharesInvariant(k Keeper) sdk.Invariant {
 
 			// convert to shares and add to the campaign shares - since we are converting shares to vouchers earlier,
 			// this conversion back to shares will never fail by design, thus we can ignore the error
-			vShares, _ := types.VouchersToShares(vouchers, campaignID)
+			vShares, _ := types.VouchersToShares(vouchers, campaignID) //nolint
 			expectedAllocatedSharesShares = types.IncreaseShares(expectedAllocatedSharesShares, vShares)
 
 			if !types.IsEqualShares(expectedAllocatedSharesShares, campaign.GetAllocatedShares()) {

--- a/x/campaign/keeper/invariants.go
+++ b/x/campaign/keeper/invariants.go
@@ -138,7 +138,7 @@ func CampaignSharesInvariant(k Keeper) sdk.Invariant {
 
 			// convert to shares and add to the campaign shares - since we are converting shares to vouchers earlier,
 			// this conversion back to shares will never fail by design, thus we can ignore the error
-			vShares, _ := types.VouchersToShares(vouchers, campaignID) //nolint
+			vShares, _ := types.VouchersToShares(vouchers, campaignID)
 			expectedAllocatedSharesShares = types.IncreaseShares(expectedAllocatedSharesShares, vShares)
 
 			if !types.IsEqualShares(expectedAllocatedSharesShares, campaign.GetAllocatedShares()) {

--- a/x/campaign/keeper/invariants_test.go
+++ b/x/campaign/keeper/invariants_test.go
@@ -48,9 +48,8 @@ func TestVestingAccountWithoutCampaignInvariant(t *testing.T) {
 }
 
 func TestCampaignSharesInvariant(t *testing.T) {
-	ctx, tk, _ := testkeeper.NewTestSetup(t)
-
 	t.Run("valid case", func(t *testing.T) {
+		ctx, tk, _ := testkeeper.NewTestSetup(t)
 		// create campaigns with some allocated shares
 		campaignID1, campaignID2 := uint64(1), uint64(2)
 		campaign := sample.Campaign(r, campaignID1)
@@ -117,6 +116,7 @@ func TestCampaignSharesInvariant(t *testing.T) {
 	})
 
 	t.Run("campaign with empty allocated share is valid", func(t *testing.T) {
+		ctx, tk, _ := testkeeper.NewTestSetup(t)
 		tk.CampaignKeeper.SetCampaign(ctx, sample.Campaign(r, 3))
 
 		msg, broken := keeper.CampaignSharesInvariant(*tk.CampaignKeeper)(ctx)
@@ -124,6 +124,7 @@ func TestCampaignSharesInvariant(t *testing.T) {
 	})
 
 	t.Run("mainnet vesting account has invalid total shares", func(t *testing.T) {
+		ctx, tk, _ := testkeeper.NewTestSetup(t)
 		tk.CampaignKeeper.SetMainnetVestingAccount(ctx, types.MainnetVestingAccount{
 			CampaignID:     0,
 			Address:        sample.Address(r),
@@ -135,6 +136,7 @@ func TestCampaignSharesInvariant(t *testing.T) {
 	})
 
 	t.Run("allocated shares cannot be converted to vouchers", func(t *testing.T) {
+		ctx, tk, _ := testkeeper.NewTestSetup(t)
 		campaignID := uint64(4)
 		campaign := sample.Campaign(r, campaignID)
 		coins := tc.Coins(t, "100foo,200bar")
@@ -153,6 +155,7 @@ func TestCampaignSharesInvariant(t *testing.T) {
 	})
 
 	t.Run("invalid allocated shares", func(t *testing.T) {
+		ctx, tk, _ := testkeeper.NewTestSetup(t)
 		campaignID := uint64(4)
 		campaign := sample.Campaign(r, campaignID)
 		campaign.AllocatedShares = types.IncreaseShares(

--- a/x/campaign/keeper/total_shares_test.go
+++ b/x/campaign/keeper/total_shares_test.go
@@ -14,5 +14,4 @@ func TestMaximumSharesGet(t *testing.T) {
 	tk.CampaignKeeper.SetTotalShares(ctx, value)
 	got := tk.CampaignKeeper.GetTotalShares(ctx)
 	require.Equal(t, value, got)
-
 }

--- a/x/campaign/types/share_vesting_options_test.go
+++ b/x/campaign/types/share_vesting_options_test.go
@@ -36,6 +36,11 @@ func TestDelayedVesting_Validate(t *testing.T) {
 		valid  bool
 	}{
 		{
+			name:   "invalid share vesting options",
+			option: types.ShareVestingOptions{},
+			valid:  false,
+		},
+		{
 			name: "no total shares",
 			option: *types.NewShareDelayedVesting(
 				nil,

--- a/x/campaign/types/shares_test.go
+++ b/x/campaign/types/shares_test.go
@@ -290,3 +290,59 @@ func TestSharesIsAllLTE(t *testing.T) {
 		})
 	}
 }
+
+func TestSharesEmpty(t *testing.T) {
+	for _, tc := range []struct {
+		desc   string
+		shares campaign.Shares
+		empty  bool
+	}{
+		{
+			desc:   "empty is valid",
+			shares: campaign.EmptyShares(),
+			empty:  true,
+		},
+		{
+			desc:   "not empty is invalid",
+			shares: tc.Shares(t, "100foo"),
+			empty:  false,
+		},
+		{
+			desc:   "nil is valid",
+			shares: campaign.Shares(nil),
+			empty:  true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.empty, tc.shares.Empty())
+		})
+	}
+}
+
+func TestSharesString(t *testing.T) {
+	for _, tc := range []struct {
+		desc   string
+		shares campaign.Shares
+		str    string
+	}{
+		{
+			desc:   "empty shares",
+			shares: campaign.EmptyShares(),
+			str:    "",
+		},
+		{
+			desc:   "one denom",
+			shares: tc.Shares(t, "100foo"),
+			str:    fmt.Sprintf("100%sfoo", campaign.SharePrefix),
+		},
+		{
+			desc:   "more denoms",
+			shares: tc.Shares(t, "100foo,100bar"),
+			str:    fmt.Sprintf("100%sbar,100%sfoo", campaign.SharePrefix, campaign.SharePrefix),
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.str, tc.shares.String())
+		})
+	}
+}

--- a/x/participation/genesis_test.go
+++ b/x/participation/genesis_test.go
@@ -14,7 +14,7 @@ func TestGenesis(t *testing.T) {
 	ctx, tk, _ := testkeeper.NewTestSetup(t)
 	r := sample.Rand()
 
-	genesisState := sample.ParticipationGenesisState(r)
+	genesisState := sample.ParticipationGenesisStateWithAllocations(r)
 	participation.InitGenesis(ctx, *tk.ParticipationKeeper, genesisState)
 	got := participation.ExportGenesis(ctx, *tk.ParticipationKeeper)
 

--- a/x/participation/keeper/grpc_available_allocations_test.go
+++ b/x/participation/keeper/grpc_available_allocations_test.go
@@ -46,7 +46,7 @@ func TestShowAvailableAllocationsQuery(t *testing.T) {
 			request: &types.QueryGetAvailableAllocationsRequest{
 				Address: strconv.Itoa(100000),
 			},
-			err: status.Error(codes.InvalidArgument, "decoding bech32 failed: invalid bech32 string length 6"),
+			err: status.Error(codes.InvalidArgument, "decoding bech32 failed: invalid bech32 string length 6: invalid address"),
 		},
 		{
 			desc: "invalid request",

--- a/x/participation/keeper/grpc_total_allocations_test.go
+++ b/x/participation/keeper/grpc_total_allocations_test.go
@@ -46,7 +46,7 @@ func TestShowTotalAllocationsQuery(t *testing.T) {
 			request: &types.QueryGetTotalAllocationsRequest{
 				Address: strconv.Itoa(100000),
 			},
-			err: status.Error(codes.InvalidArgument, "decoding bech32 failed: invalid bech32 string length 6"),
+			err: status.Error(codes.InvalidArgument, "decoding bech32 failed: invalid bech32 string length 6: invalid address"),
 		},
 		{
 			desc: "invalid request",

--- a/x/participation/keeper/msg_participate_test.go
+++ b/x/participation/keeper/msg_participate_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ func Test_msgServer_Participate(t *testing.T) {
 		endTime                          = sdkCtx.BlockTime().Add(time.Hour * 24 * 7)
 		validRegistrationTime            = sdkCtx.BlockTime().Add(time.Hour * 6)
 		allocationPrice                  = types.AllocationPrice{Bonded: sdk.NewInt(100)}
-		addrsWithDelsTier                = []string{sample.Address(r), sample.Address(r), sample.Address(r)}
+		addrsWithDelsTier                = []string{sample.Address(r), sample.Address(r), sample.Address(r), sample.Address(r)}
 		availableAllocsTier              = make([]uint64, len(addrsWithDelsTier))
 	)
 
@@ -106,6 +107,16 @@ func Test_msgServer_Participate(t *testing.T) {
 			blockTime:             time.Unix(1, 0),
 		},
 		{
+			name: "invalid message",
+			msg: &types.MsgParticipate{
+				Participant: "",
+				AuctionID:   auctionRegistrationPeriodID,
+				TierID:      1,
+			},
+			err:       sdkerrors.ErrInvalidAddress,
+			blockTime: validRegistrationTime,
+		},
+		{
 			name: "should prevent participating twice in the same auction",
 			msg: &types.MsgParticipate{
 				Participant: addrsWithDelsTier[0],
@@ -174,6 +185,16 @@ func Test_msgServer_Participate(t *testing.T) {
 			},
 			err:       types.ErrParticipationNotAllowed,
 			blockTime: sdkCtx.BlockTime(),
+		},
+		{
+			name: "should prevent participating if tier amount greater than auction max bid amount",
+			msg: &types.MsgParticipate{
+				Participant: addrsWithDelsTier[3],
+				AuctionID:   auctionRegistrationPeriodID,
+				TierID:      4,
+			},
+			err:       types.ErrInvalidBidder,
+			blockTime: validRegistrationTime,
 		},
 	}
 	for _, tt := range tests {

--- a/x/participation/keeper/msg_participate_test.go
+++ b/x/participation/keeper/msg_participate_test.go
@@ -1,11 +1,11 @@
 package keeper_test
 
 import (
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"testing"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	fundraisingtypes "github.com/tendermint/fundraising/x/fundraising/types"
 

--- a/x/participation/keeper/total_allocations.go
+++ b/x/participation/keeper/total_allocations.go
@@ -4,6 +4,7 @@ import (
 	"math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/tendermint/spn/x/participation/types"
 )
@@ -14,7 +15,7 @@ func (k Keeper) GetTotalAllocations(ctx sdk.Context, address string) (uint64, er
 
 	accAddr, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
-		return 0, err
+		return 0, sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, err.Error())
 	}
 
 	// count total shares for account

--- a/x/participation/types/genesis_test.go
+++ b/x/participation/types/genesis_test.go
@@ -116,6 +116,18 @@ func TestGenesisState_Validate(t *testing.T) {
 			valid: false,
 		},
 		{
+			desc: "invalid address in auctionUsedAllocations",
+			genState: &types.GenesisState{
+				AuctionUsedAllocationsList: []types.AuctionUsedAllocations{
+					{
+						Address:   addr1,
+						AuctionID: auctionID1,
+					},
+				},
+			},
+			valid: false,
+		},
+		{
 			desc: "mismatch between usedAllocations and auctionUsedAllocations",
 			genState: &types.GenesisState{
 				UsedAllocationsList: []types.UsedAllocations{

--- a/x/participation/types/genesis_test.go
+++ b/x/participation/types/genesis_test.go
@@ -97,6 +97,11 @@ func TestGenesisState_Validate(t *testing.T) {
 		{
 			desc: "duplicated auctionUsedAllocations",
 			genState: &types.GenesisState{
+				UsedAllocationsList: []types.UsedAllocations{
+					{
+						Address: addr1,
+					},
+				},
 				AuctionUsedAllocationsList: []types.AuctionUsedAllocations{
 					{
 						Address:   addr1,

--- a/x/participation/types/genesis_test.go
+++ b/x/participation/types/genesis_test.go
@@ -123,13 +123,7 @@ func TestGenesisState_Validate(t *testing.T) {
 					{
 						Address:        addr1,
 						AuctionID:      auctionID1,
-						NumAllocations: 1,
-						Withdrawn:      false,
-					},
-					{
-						Address:        addr1,
-						AuctionID:      auctionID2,
-						NumAllocations: 1,
+						NumAllocations: 2,
 						Withdrawn:      false,
 					},
 					{

--- a/x/participation/types/params_test.go
+++ b/x/participation/types/params_test.go
@@ -30,6 +30,22 @@ func TestParamsValidate(t *testing.T) {
 			err: errors.New("value for 'bonded' must be greater than zero"),
 		},
 		{
+			name: "invalid participation tier list",
+			params: NewParams(
+				DefaultAllocationPrice,
+				[]Tier{
+					{
+						TierID:              0,
+						RequiredAllocations: 1,
+						Benefits:            TierBenefits{MaxBidAmount: sdk.ZeroInt()},
+					},
+				},
+				DefaultRegistrationPeriod,
+				DefaultWithdrawalDelay,
+			),
+			err: errors.New("max bid amount must be greater than zero"),
+		},
+		{
 			name: "invalid registration period",
 			params: NewParams(
 				DefaultAllocationPrice,

--- a/x/profile/types/genesis_test.go
+++ b/x/profile/types/genesis_test.go
@@ -12,6 +12,14 @@ import (
 )
 
 func TestGenesisState_Validate(t *testing.T) {
+	var (
+		addr1   = sample.Address(r)
+		addr2   = sample.Address(r)
+		addr3   = sample.Address(r)
+		opAddr1 = sample.Address(r)
+		opAddr2 = sample.Address(r)
+		opAddr3 = sample.Address(r)
+	)
 	for _, tc := range []struct {
 		desc     string
 		genState *types.GenesisState
@@ -23,11 +31,45 @@ func TestGenesisState_Validate(t *testing.T) {
 			valid:    true,
 		},
 		{
-			desc:     "valid genesis state",
+			desc: "valid genesis state",
 			genState: &types.GenesisState{
+				ValidatorList: []types.Validator{
+					{Address: addr1, OperatorAddresses: []string{opAddr1}},
+					{Address: addr2, OperatorAddresses: []string{opAddr2}},
+					{Address: addr3, OperatorAddresses: []string{opAddr3}},
+				},
+				ValidatorByOperatorAddressList: []types.ValidatorByOperatorAddress{
+					{OperatorAddress: opAddr1, ValidatorAddress: addr1},
+					{OperatorAddress: opAddr2, ValidatorAddress: addr2},
+					{OperatorAddress: opAddr3, ValidatorAddress: addr3},
+				},
+				CoordinatorByAddressList: []types.CoordinatorByAddress{
+					{CoordinatorID: 0, Address: addr1},
+					{CoordinatorID: 1, Address: addr2},
+					{CoordinatorID: 2, Address: addr3},
+				},
+				CoordinatorList: []types.Coordinator{
+					{CoordinatorID: 0, Address: addr1, Active: true},
+					{CoordinatorID: 1, Address: addr2, Active: true},
+					{CoordinatorID: 2, Address: addr3, Active: true},
+				},
+				CoordinatorCounter: 4,
 				// this line is used by starport scaffolding # types/genesis/validField
 			},
 			valid: true,
+		},
+		{
+			desc: "invalid genesis state",
+			genState: &types.GenesisState{
+				ValidatorList: []types.Validator{
+					{Address: addr1, OperatorAddresses: []string{opAddr1}},
+				},
+				ValidatorByOperatorAddressList: []types.ValidatorByOperatorAddress{
+					{OperatorAddress: opAddr1, ValidatorAddress: addr1},
+					{OperatorAddress: opAddr2, ValidatorAddress: addr2},
+				},
+			},
+			valid: false,
 		},
 		// this line is used by starport scaffolding # types/genesis/testcase
 	} {
@@ -101,6 +143,19 @@ func TestGenesisStateValidateValidator(t *testing.T) {
 				},
 			},
 			err: errors.New("duplicated index for validatorByOperatorAddress"),
+		},
+		{
+			name: "missing validator address",
+			genState: &types.GenesisState{
+				ValidatorList: []types.Validator{
+					{Address: addr1, OperatorAddresses: []string{opAddr1}},
+				},
+				ValidatorByOperatorAddressList: []types.ValidatorByOperatorAddress{
+					{OperatorAddress: opAddr1, ValidatorAddress: addr1},
+					{OperatorAddress: opAddr2, ValidatorAddress: addr2},
+				},
+			},
+			err: errors.New("validator operator address not found for Validator"),
 		},
 		{
 			name: "missing operator address in the validator list",


### PR DESCRIPTION
Part of #687

Increase code coverage of the modules above with the excetpion of `keeper/grpc_params` (for `campaign` and `participation`) that are handled by @ludtb in #700