### PR TITLE
fix(`simulation`): ensure no int overflow for bank state generation

### DIFF
--- a/app/simulation_test.go
+++ b/app/simulation_test.go
@@ -52,7 +52,6 @@ func interBlockCacheOpt() func(*baseapp.BaseApp) {
 
 // go test ./app -v -benchmem -run=^$ -bench ^BenchmarkSimulation -Commit=true -cpuprofile cpu.out
 func BenchmarkSimulation(b *testing.B) {
-	simapp.FlagSeedValue = 10
 	simapp.FlagVerboseValue = true
 	simapp.FlagOnOperationValue = true
 	simapp.FlagAllInvariantsValue = true

--- a/app/simutil/app_state.go
+++ b/app/simutil/app_state.go
@@ -34,14 +34,14 @@ func CustomAppStateFn(cdc codec.JSONCodec, simManager *module.SimulationManager)
 		chainID = config.ChainID
 		appParams := make(simtypes.AppParams)
 
-		maxInitialStake := math.MaxInt64 / (numAccs + MaxNumBonded)
+		maxInitialCoin := math.MaxInt64 / (numAccs + MaxNumBonded)
 
 		// generate a random amount of initial stake coins and a random initial
 		// number of bonded accounts
 		var initialStake, numInitiallyBonded int64
 		appParams.GetOrGenerate(
 			cdc, simappparams.StakePerAccount, &initialStake, r,
-			func(r *rand.Rand) { initialStake = r.Int63n(maxInitialStake) },
+			func(r *rand.Rand) { initialStake = r.Int63n(maxInitialCoin) },
 		)
 		appParams.GetOrGenerate(
 			cdc, simappparams.InitiallyBondedValidators, &numInitiallyBonded, r,
@@ -119,7 +119,7 @@ func CustomAppStateFn(cdc codec.JSONCodec, simManager *module.SimulationManager)
 		totalNewCoins := sdk.NewCoins()
 		for i, balance := range bankState.Balances {
 			if r.Int63n(100) < 20 {
-				auctionCoinAmt := r.Int63n(999_000_000_000_000) + 1_000_000_000_000
+				auctionCoinAmt := r.Int63n(maxInitialCoin)
 				auctionCoin := sdk.NewCoin(AuctionCoinDenom, sdk.NewInt(auctionCoinAmt))
 				newBalance := balance.Coins.Add(auctionCoin)
 				bankState.Balances[i].Coins = newBalance

--- a/app/simutil/app_state.go
+++ b/app/simutil/app_state.go
@@ -3,6 +3,7 @@ package simutil
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/rand"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 
 const (
 	AuctionCoinDenom = "auction"
+	MaxNumBonded     = 300
 )
 
 // CustomAppStateFn returns the initial application state using the simulation parameters.
@@ -32,16 +34,18 @@ func CustomAppStateFn(cdc codec.JSONCodec, simManager *module.SimulationManager)
 		chainID = config.ChainID
 		appParams := make(simtypes.AppParams)
 
+		maxInitialStake := math.MaxInt64 / (numAccs + MaxNumBonded)
+
 		// generate a random amount of initial stake coins and a random initial
 		// number of bonded accounts
 		var initialStake, numInitiallyBonded int64
 		appParams.GetOrGenerate(
 			cdc, simappparams.StakePerAccount, &initialStake, r,
-			func(r *rand.Rand) { initialStake = r.Int63n(1e16) },
+			func(r *rand.Rand) { initialStake = r.Int63n(maxInitialStake) },
 		)
 		appParams.GetOrGenerate(
 			cdc, simappparams.InitiallyBondedValidators, &numInitiallyBonded, r,
-			func(r *rand.Rand) { numInitiallyBonded = int64(r.Intn(300) + 200) },
+			func(r *rand.Rand) { numInitiallyBonded = r.Int63n(MaxNumBonded) },
 		)
 
 		if numInitiallyBonded > numAccs {
@@ -52,9 +56,10 @@ func CustomAppStateFn(cdc codec.JSONCodec, simManager *module.SimulationManager)
 			`Selected randomly generated parameters for simulated genesis:
 {
   stake_per_account: "%d",
-  initially_bonded_validators: "%d"
+  initially_bonded_validators: "%d",
+  num_accs: "%d"
 }
-`, initialStake, numInitiallyBonded,
+`, initialStake, numInitiallyBonded, numAccs,
 		)
 
 		simState := &module.SimulationState{


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #720

### What does this PR does?

Ensure there is no `int64` overflow when generating the initial bank state.  The maximum amount of coins per account is `int64Max / totalNumAccounts`.