### PR TITLE
fix: usage of `rand` in simulation test

### DIFF
--- a/x/campaign/simulation/simulation.go
+++ b/x/campaign/simulation/simulation.go
@@ -269,7 +269,7 @@ func SimulateMsgBurnVouchers(
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
-		campID, simAccount, vouchers, found := GetAccountWithVouchers(ctx, bk, k, accs, false)
+		campID, simAccount, vouchers, found := GetAccountWithVouchers(r, ctx, bk, k, accs, false)
 		if !found {
 			return simtypes.NoOpMsg(types.ModuleName, types.TypeMsgBurnVouchers, "skip burn vouchers"), nil, nil
 		}
@@ -292,7 +292,7 @@ func SimulateMsgRedeemVouchers(
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
-		campID, simAccount, vouchers, found := GetAccountWithVouchers(ctx, bk, k, accs, true)
+		campID, simAccount, vouchers, found := GetAccountWithVouchers(r, ctx, bk, k, accs, true)
 		if !found {
 			return simtypes.NoOpMsg(types.ModuleName, types.TypeMsgRedeemVouchers, "skip redeem vouchers"), nil, nil
 		}
@@ -343,7 +343,7 @@ func SimulateMsgSendVouchers(
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
 	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
-		_, simAccount, vouchers, found := GetAccountWithVouchers(ctx, bk, k, accs, false)
+		_, simAccount, vouchers, found := GetAccountWithVouchers(r, ctx, bk, k, accs, false)
 		if !found {
 			return simtypes.NoOpMsg(banktypes.ModuleName, banktypes.TypeMsgSend, "skip send vouchers"), nil, nil
 		}

--- a/x/campaign/simulation/store.go
+++ b/x/campaign/simulation/store.go
@@ -137,6 +137,7 @@ func GetSharesFromCampaign(r *rand.Rand, ctx sdk.Context, k keeper.Keeper, campI
 
 // GetAccountWithVouchers returns an account that has vouchers for a campaign
 func GetAccountWithVouchers(
+	r *rand.Rand,
 	ctx sdk.Context,
 	bk types.BankKeeper,
 	k keeper.Keeper,
@@ -179,7 +180,7 @@ func GetAccountWithVouchers(
 		coinCampID, err := types.VoucherCampaign(coin.Denom)
 		if err == nil && coinCampID == campID {
 			// retain a random portion of the balance in the range [0, coin.Amount)
-			retainAmt := sdk.NewInt(rand.Int63n(coin.Amount.Int64()))
+			retainAmt := sdk.NewInt(r.Int63n(coin.Amount.Int64()))
 			coin.Amount = coin.Amount.Sub(retainAmt)
 			coins = append(coins, coin)
 		}

--- a/x/campaign/simulation/store_test.go
+++ b/x/campaign/simulation/store_test.go
@@ -222,7 +222,7 @@ func TestGetAccountWithVouchers(t *testing.T) {
 	}
 
 	t.Run("no account", func(t *testing.T) {
-		_, _, _, found := simcampaign.GetAccountWithVouchers(ctx, tk.BankKeeper, *tk.CampaignKeeper, accs, false)
+		_, _, _, found := simcampaign.GetAccountWithVouchers(r, ctx, tk.BankKeeper, *tk.CampaignKeeper, accs, false)
 		require.False(t, found)
 	})
 
@@ -236,7 +236,7 @@ func TestGetAccountWithVouchers(t *testing.T) {
 		campaign.MainnetID = tk.LaunchKeeper.AppendChain(ctx, chain)
 		campaign.CampaignID = tk.CampaignKeeper.AppendCampaign(ctx, campaign)
 		mint(acc.Address, sample.Vouchers(r, campaign.CampaignID))
-		campID, acc, coins, found := simcampaign.GetAccountWithVouchers(ctx, tk.BankKeeper, *tk.CampaignKeeper, accs, false)
+		campID, acc, coins, found := simcampaign.GetAccountWithVouchers(r, ctx, tk.BankKeeper, *tk.CampaignKeeper, accs, false)
 		require.True(t, found)
 		require.EqualValues(t, campaign.CampaignID, campID)
 		require.False(t, coins.Empty())
@@ -249,7 +249,7 @@ func TestGetAccountWithVouchers(t *testing.T) {
 		campaign.MainnetInitialized = false
 		campaign.CampaignID = tk.CampaignKeeper.AppendCampaign(ctx, campaign)
 		mint(acc.Address, sample.Vouchers(r, campaign.CampaignID))
-		campID, acc, coins, found := simcampaign.GetAccountWithVouchers(ctx, tk.BankKeeper, *tk.CampaignKeeper, accs, true)
+		campID, acc, coins, found := simcampaign.GetAccountWithVouchers(r, ctx, tk.BankKeeper, *tk.CampaignKeeper, accs, true)
 		require.True(t, found)
 		require.EqualValues(t, campaign.CampaignID, campID)
 		require.False(t, coins.Empty())


### PR DESCRIPTION
Change `rand` usage with `r` variable to prevent non-determinism issue in simulation tests