### PR TITLE
fix(`campaign`): return correct request number in campaign summary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/goccy/go-yaml v1.9.4 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gogo/gateway v1.1.0 // indirect
+	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/btree v1.0.0 // indirect
@@ -84,6 +85,7 @@ require (
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/gtank/merlin v0.1.1 // indirect
 	github.com/gtank/ristretto255 v0.1.2 // indirect
@@ -167,6 +169,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	nhooyr.io/websocket v1.8.6 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -598,6 +598,8 @@ github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2V
 github.com/golang-sql/sqlexp v0.0.0-20170517235910-f1bb20e5a188/go.mod h1:vXjM/+wXQnTPR4KqTKDgJukSZ6amVRtWMPEjE6sQoK8=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
+github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -724,6 +726,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.0 h1:ESEyqQqXXFIcImj/BE8oKEX37Zsuceb2cZI+EL/zNCY=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.10.0/go.mod h1:XnLCLFp3tjoZJszVKjfpyAK6J8sYIcQXWQxmqLWF21I=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/gtank/merlin v0.1.1-0.20191105220539-8318aed1a79f/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/bIQ+s=
@@ -2055,4 +2059,6 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=

--- a/x/campaign/keeper/grpc_campaign_summary.go
+++ b/x/campaign/keeper/grpc_campaign_summary.go
@@ -95,7 +95,7 @@ func (k Keeper) GetCampaignSummary(ctx sdk.Context, campaign types.Campaign) (cs
 			LaunchTriggered: chain.LaunchTriggered,
 			SourceURL:       chain.SourceURL,
 			SourceHash:      chain.SourceHash,
-			RequestNb:       k.launchKeeper.GetRequestCounter(ctx, mostRecentLaunchID),
+			RequestNb:       k.launchKeeper.GetRequestCount(ctx, mostRecentLaunchID),
 			ValidatorNb:     k.launchKeeper.GetGenesisValidatorCount(ctx, mostRecentLaunchID),
 		}
 

--- a/x/campaign/keeper/keeper.go
+++ b/x/campaign/keeper/keeper.go
@@ -15,7 +15,7 @@ import (
 
 type LaunchKeeper interface {
 	GetChain(ctx sdk.Context, launchID uint64) (val launchtypes.Chain, found bool)
-	GetRequestCounter(ctx sdk.Context, launchID uint64) (count uint64)
+	GetRequestCount(ctx sdk.Context, launchID uint64) (count uint64)
 	GetGenesisValidatorCount(ctx sdk.Context, launchID uint64) (count uint64)
 	CreateNewChain(
 		ctx sdk.Context,

--- a/x/launch/keeper/request.go
+++ b/x/launch/keeper/request.go
@@ -63,6 +63,20 @@ func (k Keeper) AppendRequest(ctx sdk.Context, request types.Request) uint64 {
 	return counter
 }
 
+// GetRequestCount returns the number of request from a launch ID
+// TODO: add tests https://github.com/tendermint/spn/issues/642
+func (k Keeper) GetRequestCount(ctx sdk.Context, launchID uint64) (count uint64) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.RequestPoolKey(launchID))
+	iterator := sdk.KVStorePrefixIterator(store, []byte{})
+
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		count++
+	}
+
+	return count
+}
+
 // GetRequest returns a request from its index
 func (k Keeper) GetRequest(
 	ctx sdk.Context,

--- a/x/launch/keeper/request.go
+++ b/x/launch/keeper/request.go
@@ -66,7 +66,8 @@ func (k Keeper) AppendRequest(ctx sdk.Context, request types.Request) uint64 {
 // GetRequestCount returns the number of request from a launch ID
 // TODO: add tests https://github.com/tendermint/spn/issues/642
 func (k Keeper) GetRequestCount(ctx sdk.Context, launchID uint64) (count uint64) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.RequestPoolKey(launchID))
+	requestPoolPrefix := append(types.KeyPrefix(types.RequestKeyPrefix), types.RequestPoolKey(launchID)...)
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), requestPoolPrefix)
 	iterator := sdk.KVStorePrefixIterator(store, []byte{})
 
 	defer iterator.Close()


### PR DESCRIPTION
Implement a method `GetRequestCount` to get the number of requests instead of relying on the request counter that is used for determining the request ID

This count method iterates elements, in the store eventually we want to optimize this logic by adding a new entry in the store 