### PR TITLE
refactor(`campaign`): `MainnetAccountBalanceAll`: omit account with empty balance

### DIFF
--- a/x/campaign/keeper/grpc_mainnet_account.go
+++ b/x/campaign/keeper/grpc_mainnet_account.go
@@ -84,12 +84,16 @@ func (k Keeper) MainnetAccountBalanceAll(c context.Context, req *types.QueryAllM
 			return status.Errorf(codes.Internal, "balance can't be calculated for account %s: %s", acc.Address, err.Error())
 		}
 
-		mainnetAccountBalance := types.MainnetAccountBalance{
-			CampaignID: acc.CampaignID,
-			Address:    acc.Address,
-			Coins:      balance,
+		// add the balance if not zero
+		if !balance.IsZero() {
+			mainnetAccountBalance := types.MainnetAccountBalance{
+				CampaignID: acc.CampaignID,
+				Address:    acc.Address,
+				Coins:      balance,
+			}
+			mainnetAccountBalances = append(mainnetAccountBalances, mainnetAccountBalance)
 		}
-		mainnetAccountBalances = append(mainnetAccountBalances, mainnetAccountBalance)
+
 		return nil
 	})
 


### PR DESCRIPTION
Since the client would rely on this query to construct the genesis account balances and an account can't have an empty balance in the genesis. This PR modifies `MainnetAccountBalanceAll` to omit the mainnet account with an empty balance:

Example: if all the shares of the accounts reflect tokens that are not in the total supply of the mainnet
