### PR TITLE
feat(`campaign`): add simulation for `MsgUpdateSpecialAllocations`

### DIFF
--- a/x/campaign/module_simulation.go
+++ b/x/campaign/module_simulation.go
@@ -14,27 +14,29 @@ import (
 )
 
 const (
-	defaultWeightMsgCreateCampaign    = 25
-	defaultWeightMsgEditCampaign      = 20
-	defaultWeightMsgUpdateTotalSupply = 20
-	defaultWeightMsgInitializeMainnet = 15
-	defaultWeightMsgAddShares         = 20
-	defaultWeightMsgAddVestingOptions = 20
-	defaultWeightMsgMintVouchers      = 20
-	defaultWeightMsgBurnVouchers      = 20
-	defaultWeightMsgRedeemVouchers    = 20
-	defaultWeightMsgUnredeemVouchers  = 20
+	defaultWeightMsgCreateCampaign           = 25
+	defaultWeightMsgEditCampaign             = 20
+	defaultWeightMsgUpdateTotalSupply        = 20
+	defaultWeightMsgInitializeMainnet        = 15
+	defaultWeightMsgUpdateSpecialAllocations = 20
+	defaultWeightMsgAddShares                = 20
+	defaultWeightMsgAddVestingOptions        = 20
+	defaultWeightMsgMintVouchers             = 20
+	defaultWeightMsgBurnVouchers             = 20
+	defaultWeightMsgRedeemVouchers           = 20
+	defaultWeightMsgUnredeemVouchers         = 20
 
-	opWeightMsgCreateCampaign    = "op_weight_msg_create_campaign"
-	opWeightMsgEditCampaign      = "op_weight_msg_edit_campaign"
-	opWeightMsgUpdateTotalSupply = "op_weight_msg_update_total_supply"
-	opWeightMsgInitializeMainnet = "op_weight_msg_initialize_mainnet"
-	opWeightMsgAddShares         = "op_weight_msg_add_shares"
-	opWeightMsgAddVestingOptions = "op_weight_msg_add_vesting_options"
-	opWeightMsgMintVouchers      = "op_weight_msg_mint_vouchers"
-	opWeightMsgBurnVouchers      = "op_weight_msg_burn_vouchers"
-	opWeightMsgRedeemVouchers    = "op_weight_msg_redeem_vouchers"
-	opWeightMsgUnredeemVouchers  = "op_weight_msg_unredeem_vouchers"
+	opWeightMsgCreateCampaign           = "op_weight_msg_create_campaign"
+	opWeightMsgEditCampaign             = "op_weight_msg_edit_campaign"
+	opWeightMsgUpdateTotalSupply        = "op_weight_msg_update_total_supply"
+	opWeightMsgInitializeMainnet        = "op_weight_msg_initialize_mainnet"
+	opWeightMsgUpdateSpecialAllocations = "op_weight_msg_update_special_allocations"
+	opWeightMsgAddShares                = "op_weight_msg_add_shares"
+	opWeightMsgAddVestingOptions        = "op_weight_msg_add_vesting_options"
+	opWeightMsgMintVouchers             = "op_weight_msg_mint_vouchers"
+	opWeightMsgBurnVouchers             = "op_weight_msg_burn_vouchers"
+	opWeightMsgRedeemVouchers           = "op_weight_msg_redeem_vouchers"
+	opWeightMsgUnredeemVouchers         = "op_weight_msg_unredeem_vouchers"
 
 	// this line is used by starport scaffolding # simapp/module/const
 )
@@ -69,16 +71,17 @@ func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {}
 // WeightedOperations returns the all the gov module operations with their respective weights.
 func (am AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
 	var (
-		weightMsgCreateCampaign    int
-		weightMsgEditCampaign      int
-		weightMsgUpdateTotalSupply int
-		weightMsgInitializeMainnet int
-		weightMsgAddShares         int
-		weightMsgAddVestingOptions int
-		weightMsgMintVouchers      int
-		weightMsgBurnVouchers      int
-		weightMsgRedeemVouchers    int
-		weightMsgUnredeemVouchers  int
+		weightMsgCreateCampaign           int
+		weightMsgEditCampaign             int
+		weightMsgUpdateTotalSupply        int
+		weightMsgInitializeMainnet        int
+		weightMsgUpdateSpecialAllocations int
+		weightMsgAddShares                int
+		weightMsgAddVestingOptions        int
+		weightMsgMintVouchers             int
+		weightMsgBurnVouchers             int
+		weightMsgRedeemVouchers           int
+		weightMsgUnredeemVouchers         int
 	)
 
 	appParams := simState.AppParams
@@ -101,6 +104,11 @@ func (am AppModule) WeightedOperations(simState module.SimulationState) []simtyp
 	appParams.GetOrGenerate(cdc, opWeightMsgInitializeMainnet, &weightMsgInitializeMainnet, nil,
 		func(_ *rand.Rand) {
 			weightMsgInitializeMainnet = defaultWeightMsgInitializeMainnet
+		},
+	)
+	appParams.GetOrGenerate(cdc, opWeightMsgUpdateSpecialAllocations, &weightMsgUpdateSpecialAllocations, nil,
+		func(_ *rand.Rand) {
+			weightMsgInitializeMainnet = defaultWeightMsgUpdateSpecialAllocations
 		},
 	)
 	appParams.GetOrGenerate(cdc, opWeightMsgAddShares, &weightMsgAddShares, nil,
@@ -154,6 +162,10 @@ func (am AppModule) WeightedOperations(simState module.SimulationState) []simtyp
 		simulation.NewWeightedOperation(
 			weightMsgAddShares,
 			campaignsim.SimulateMsgAddShares(am.accountKeeper, am.bankKeeper, am.profileKeeper, am.keeper),
+		),
+		simulation.NewWeightedOperation(
+			weightMsgAddShares,
+			campaignsim.SimulateMsgUpdateSpecialAllocations(am.accountKeeper, am.bankKeeper, am.profileKeeper, am.keeper),
 		),
 		simulation.NewWeightedOperation(
 			weightMsgMintVouchers,


### PR DESCRIPTION
Simulate the message by finding a campaign, and using random share numbers with pre-defined share denom
