### PR TITLE
test: implement query test suite

### DIFF
--- a/testutil/networksuite/networksuite.go
+++ b/testutil/networksuite/networksuite.go
@@ -2,9 +2,10 @@
 package networksuite
 
 import (
+	"math/rand"
+
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-
 	"github.com/tendermint/spn/testutil/network"
 	"github.com/tendermint/spn/testutil/sample"
 	launch "github.com/tendermint/spn/x/launch/types"
@@ -26,6 +27,18 @@ func (nts *NetworkTestSuite) SetupSuite() {
 	launchState := launch.GenesisState{}
 	require.NoError(nts.T(), cfg.Codec.UnmarshalJSON(cfg.GenesisState[launch.ModuleName], &launchState))
 
+	launchState = populateLaunch(r, launchState)
+
+	buf, err := cfg.Codec.MarshalJSON(&launchState)
+	require.NoError(nts.T(), err)
+	cfg.GenesisState[launch.ModuleName] = buf
+
+	nts.Network = network.New(nts.T(), cfg)
+	nts.LaunchState = launchState
+}
+
+func populateLaunch(r *rand.Rand, launchState launch.GenesisState) launch.GenesisState {
+	// add chains
 	for i := 0; i < 5; i++ {
 		chain := sample.Chain(r, uint64(i), uint64(i))
 		launchState.ChainList = append(
@@ -33,10 +46,40 @@ func (nts *NetworkTestSuite) SetupSuite() {
 			chain,
 		)
 	}
-	buf, err := cfg.Codec.MarshalJSON(&launchState)
-	require.NoError(nts.T(), err)
-	cfg.GenesisState[launch.ModuleName] = buf
 
-	nts.Network = network.New(nts.T(), cfg)
-	nts.LaunchState = launchState
+	// add genesis accounts
+	for i := 0; i < 5; i++ {
+		launchState.GenesisAccountList = append(
+			launchState.GenesisAccountList,
+			sample.GenesisAccount(r, 0, sample.Address(r)),
+		)
+	}
+
+	// add vesting accounts
+	for i := 0; i < 5; i++ {
+		launchState.VestingAccountList = append(
+			launchState.VestingAccountList,
+			sample.VestingAccount(r, 0, sample.Address(r)),
+		)
+	}
+
+	// add genesis validators
+	for i := 0; i < 5; i++ {
+		launchState.GenesisValidatorList = append(
+			launchState.GenesisValidatorList,
+			sample.GenesisValidator(r, uint64(0), sample.Address(r)),
+		)
+	}
+
+	// add request
+	for i := 0; i < 5; i++ {
+		request := sample.Request(r, 0, sample.Address(r))
+		request.RequestID = uint64(i)
+		launchState.RequestList = append(
+			launchState.RequestList,
+			request,
+		)
+	}
+
+	return launchState
 }

--- a/testutil/networksuite/networksuite.go
+++ b/testutil/networksuite/networksuite.go
@@ -1,0 +1,42 @@
+// Package networksuite provides base test suite for tests that need a local network instance
+package networksuite
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/tendermint/spn/testutil/network"
+	"github.com/tendermint/spn/testutil/sample"
+	launch "github.com/tendermint/spn/x/launch/types"
+)
+
+// NetworkTestSuite is a test suite for query tests that initializes a network instance
+type NetworkTestSuite struct {
+	suite.Suite
+	Network     *network.Network
+	LaunchState launch.GenesisState
+}
+
+// SetupSuite setups the local network with a genesis state
+func (nts *NetworkTestSuite) SetupSuite() {
+	r := sample.Rand()
+	cfg := network.DefaultConfig()
+
+	// initialize launch
+	launchState := launch.GenesisState{}
+	require.NoError(nts.T(), cfg.Codec.UnmarshalJSON(cfg.GenesisState[launch.ModuleName], &launchState))
+
+	for i := 0; i < 5; i++ {
+		chain := sample.Chain(r, uint64(i), uint64(i))
+		launchState.ChainList = append(
+			launchState.ChainList,
+			chain,
+		)
+	}
+	buf, err := cfg.Codec.MarshalJSON(&launchState)
+	require.NoError(nts.T(), err)
+	cfg.GenesisState[launch.ModuleName] = buf
+
+	nts.Network = network.New(nts.T(), cfg)
+	nts.LaunchState = launchState
+}

--- a/x/launch/client/cli/query_chain_test.go
+++ b/x/launch/client/cli/query_chain_test.go
@@ -11,36 +11,14 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/tendermint/spn/testutil/network"
-	"github.com/tendermint/spn/testutil/sample"
 	"github.com/tendermint/spn/x/launch/client/cli"
 	"github.com/tendermint/spn/x/launch/types"
 )
 
-func networkWithFooObjects(t *testing.T, n int) (*network.Network, []types.Chain) {
-	t.Helper()
-	r := sample.Rand()
-	cfg := network.DefaultConfig()
-	state := types.GenesisState{}
-	require.NoError(t, cfg.Codec.UnmarshalJSON(cfg.GenesisState[types.ModuleName], &state))
+func (suite *QueryTestSuite) TestShowChain() {
+	ctx := suite.Network.Validators[0].ClientCtx
+	chains := suite.LaunchState.ChainList
 
-	for i := 0; i < n; i++ {
-		chain := sample.Chain(r, uint64(i), uint64(i))
-		state.ChainList = append(
-			state.ChainList,
-			chain,
-		)
-	}
-	buf, err := cfg.Codec.MarshalJSON(&state)
-	require.NoError(t, err)
-	cfg.GenesisState[types.ModuleName] = buf
-	return network.New(t, cfg), state.ChainList
-}
-
-func TestShowChain(t *testing.T) {
-	net, objs := networkWithFooObjects(t, 2)
-
-	ctx := net.Validators[0].ClientCtx
 	common := []string{
 		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
 	}
@@ -53,9 +31,9 @@ func TestShowChain(t *testing.T) {
 	}{
 		{
 			desc: "found",
-			id:   fmt.Sprintf("%d", objs[0].LaunchID),
+			id:   fmt.Sprintf("%d", chains[0].LaunchID),
 			args: common,
-			obj:  objs[0],
+			obj:  chains[0],
 		},
 		{
 			desc: "not found",
@@ -64,7 +42,7 @@ func TestShowChain(t *testing.T) {
 			err:  status.Error(codes.NotFound, "not found"),
 		},
 	} {
-		t.Run(tc.desc, func(t *testing.T) {
+		suite.T().Run(tc.desc, func(t *testing.T) {
 			args := []string{tc.id}
 			args = append(args, tc.args...)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowChain(), args)
@@ -75,7 +53,7 @@ func TestShowChain(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				var resp types.QueryGetChainResponse
-				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.NoError(t, suite.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 				require.NotNil(t, resp.Chain)
 				require.Equal(t, tc.obj, resp.Chain)
 			}
@@ -83,10 +61,10 @@ func TestShowChain(t *testing.T) {
 	}
 }
 
-func TestListFoo(t *testing.T) {
-	net, objs := networkWithFooObjects(t, 5)
+func (suite *QueryTestSuite) TestListFoo() {
+	ctx := suite.Network.Validators[0].ClientCtx
+	chains := suite.LaunchState.ChainList
 
-	ctx := net.Validators[0].ClientCtx
 	request := func(next []byte, offset, limit uint64, total bool) []string {
 		args := []string{
 			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
@@ -102,40 +80,40 @@ func TestListFoo(t *testing.T) {
 		}
 		return args
 	}
-	t.Run("ByOffset", func(t *testing.T) {
+	suite.T().Run("ByOffset", func(t *testing.T) {
 		step := 2
-		for i := 0; i < len(objs); i += step {
+		for i := 0; i < len(chains); i += step {
 			args := request(nil, uint64(i), uint64(step), false)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListChain(), args)
 			require.NoError(t, err)
 			var resp types.QueryAllChainResponse
-			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, suite.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.Chain), step)
-			require.Subset(t, objs, resp.Chain)
+			require.Subset(t, chains, resp.Chain)
 		}
 	})
-	t.Run("ByKey", func(t *testing.T) {
+	suite.T().Run("ByKey", func(t *testing.T) {
 		step := 2
 		var next []byte
-		for i := 0; i < len(objs); i += step {
+		for i := 0; i < len(chains); i += step {
 			args := request(next, 0, uint64(step), false)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListChain(), args)
 			require.NoError(t, err)
 			var resp types.QueryAllChainResponse
-			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, suite.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.Chain), step)
-			require.Subset(t, objs, resp.Chain)
+			require.Subset(t, chains, resp.Chain)
 			next = resp.Pagination.NextKey
 		}
 	})
-	t.Run("Total", func(t *testing.T) {
-		args := request(nil, 0, uint64(len(objs)), true)
+	suite.T().Run("Total", func(t *testing.T) {
+		args := request(nil, 0, uint64(len(chains)), true)
 		out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListChain(), args)
 		require.NoError(t, err)
 		var resp types.QueryAllChainResponse
-		require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+		require.NoError(t, suite.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 		require.NoError(t, err)
-		require.Equal(t, len(objs), int(resp.Pagination.Total))
-		require.ElementsMatch(t, objs, resp.Chain)
+		require.Equal(t, len(chains), int(resp.Pagination.Total))
+		require.ElementsMatch(t, chains, resp.Chain)
 	})
 }

--- a/x/launch/client/cli/query_genesis_account_test.go
+++ b/x/launch/client/cli/query_genesis_account_test.go
@@ -12,36 +12,14 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/tendermint/spn/testutil/network"
-	"github.com/tendermint/spn/testutil/sample"
 	"github.com/tendermint/spn/x/launch/client/cli"
 	"github.com/tendermint/spn/x/launch/types"
 )
 
-func networkWithGenesisAccountObjects(t *testing.T, n int) (*network.Network, []types.GenesisAccount) {
-	t.Helper()
-	r := sample.Rand()
-	cfg := network.DefaultConfig()
-	state := types.GenesisState{}
-	require.NoError(t, cfg.Codec.UnmarshalJSON(cfg.GenesisState[types.ModuleName], &state))
+func (suite *QueryTestSuite) TestShowGenesisAccount() {
+	ctx := suite.Network.Validators[0].ClientCtx
+	accs := suite.LaunchState.GenesisAccountList
 
-	for i := 0; i < n; i++ {
-		state.GenesisAccountList = append(
-			state.GenesisAccountList,
-			sample.GenesisAccount(r, 0, strconv.Itoa(i)),
-		)
-	}
-	state.ChainList = append(state.ChainList, sample.Chain(r, 0, sample.Uint64(r)))
-	buf, err := cfg.Codec.MarshalJSON(&state)
-	require.NoError(t, err)
-	cfg.GenesisState[types.ModuleName] = buf
-	return network.New(t, cfg), state.GenesisAccountList
-}
-
-func TestShowGenesisAccount(t *testing.T) {
-	net, objs := networkWithGenesisAccountObjects(t, 2)
-
-	ctx := net.Validators[0].ClientCtx
 	common := []string{
 		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
 	}
@@ -56,11 +34,11 @@ func TestShowGenesisAccount(t *testing.T) {
 	}{
 		{
 			desc:       "found",
-			idLaunchID: strconv.Itoa(int(objs[0].LaunchID)),
-			idAddress:  objs[0].Address,
+			idLaunchID: strconv.Itoa(int(accs[0].LaunchID)),
+			idAddress:  accs[0].Address,
 
 			args: common,
-			obj:  objs[0],
+			obj:  accs[0],
 		},
 		{
 			desc:       "not found",
@@ -71,7 +49,7 @@ func TestShowGenesisAccount(t *testing.T) {
 			err:  status.Error(codes.NotFound, "not found"),
 		},
 	} {
-		t.Run(tc.desc, func(t *testing.T) {
+		suite.T().Run(tc.desc, func(t *testing.T) {
 			args := []string{
 				tc.idLaunchID,
 				tc.idAddress,
@@ -85,7 +63,7 @@ func TestShowGenesisAccount(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				var resp types.QueryGetGenesisAccountResponse
-				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.NoError(t, suite.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 				require.NotNil(t, resp.GenesisAccount)
 				require.Equal(t, tc.obj, resp.GenesisAccount)
 			}
@@ -93,11 +71,11 @@ func TestShowGenesisAccount(t *testing.T) {
 	}
 }
 
-func TestListGenesisAccount(t *testing.T) {
-	net, objs := networkWithGenesisAccountObjects(t, 5)
+func (suite *QueryTestSuite) TestListGenesisAccount() {
+	ctx := suite.Network.Validators[0].ClientCtx
+	accs := suite.LaunchState.GenesisAccountList
 
-	chainID := objs[0].LaunchID
-	ctx := net.Validators[0].ClientCtx
+	chainID := accs[0].LaunchID
 	request := func(chainID uint64, next []byte, offset, limit uint64, total bool) []string {
 		args := []string{
 			strconv.Itoa(int(chainID)),
@@ -114,40 +92,40 @@ func TestListGenesisAccount(t *testing.T) {
 		}
 		return args
 	}
-	t.Run("ByOffset", func(t *testing.T) {
+	suite.T().Run("ByOffset", func(t *testing.T) {
 		step := 2
-		for i := 0; i < len(objs); i += step {
+		for i := 0; i < len(accs); i += step {
 			args := request(chainID, nil, uint64(i), uint64(step), false)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListGenesisAccount(), args)
 			require.NoError(t, err)
 			var resp types.QueryAllGenesisAccountResponse
-			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, suite.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.GenesisAccount), step)
-			require.Subset(t, objs, resp.GenesisAccount)
+			require.Subset(t, accs, resp.GenesisAccount)
 		}
 	})
-	t.Run("ByKey", func(t *testing.T) {
+	suite.T().Run("ByKey", func(t *testing.T) {
 		step := 2
 		var next []byte
-		for i := 0; i < len(objs); i += step {
+		for i := 0; i < len(accs); i += step {
 			args := request(chainID, next, 0, uint64(step), false)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListGenesisAccount(), args)
 			require.NoError(t, err)
 			var resp types.QueryAllGenesisAccountResponse
-			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, suite.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.GenesisAccount), step)
-			require.Subset(t, objs, resp.GenesisAccount)
+			require.Subset(t, accs, resp.GenesisAccount)
 			next = resp.Pagination.NextKey
 		}
 	})
-	t.Run("Total", func(t *testing.T) {
-		args := request(chainID, nil, 0, uint64(len(objs)), true)
+	suite.T().Run("Total", func(t *testing.T) {
+		args := request(chainID, nil, 0, uint64(len(accs)), true)
 		out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListGenesisAccount(), args)
 		require.NoError(t, err)
 		var resp types.QueryAllGenesisAccountResponse
-		require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+		require.NoError(t, suite.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 		require.NoError(t, err)
-		require.Equal(t, len(objs), int(resp.Pagination.Total))
-		require.ElementsMatch(t, objs, resp.GenesisAccount)
+		require.Equal(t, len(accs), int(resp.Pagination.Total))
+		require.ElementsMatch(t, accs, resp.GenesisAccount)
 	})
 }

--- a/x/launch/client/cli/query_test.go
+++ b/x/launch/client/cli/query_test.go
@@ -1,0 +1,17 @@
+package cli_test
+
+import (
+	"github.com/stretchr/testify/suite"
+	"github.com/tendermint/spn/testutil/networksuite"
+	"testing"
+)
+
+// QueryTestSuite is a test suite for query tests
+type QueryTestSuite struct {
+	networksuite.NetworkTestSuite
+}
+
+// TestQueryTestSuite runs test of the query suite
+func TestQueryTestSuite(t *testing.T) {
+	suite.Run(t, new(QueryTestSuite))
+}

--- a/x/launch/client/cli/query_vesting_account_test.go
+++ b/x/launch/client/cli/query_vesting_account_test.go
@@ -12,35 +12,14 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/tendermint/spn/testutil/network"
-	"github.com/tendermint/spn/testutil/sample"
 	"github.com/tendermint/spn/x/launch/client/cli"
 	"github.com/tendermint/spn/x/launch/types"
 )
 
-func networkWithVestingAccountObjects(t *testing.T, n int) (*network.Network, []types.VestingAccount) {
-	t.Helper()
-	r := sample.Rand()
-	cfg := network.DefaultConfig()
-	state := types.GenesisState{}
-	require.NoError(t, cfg.Codec.UnmarshalJSON(cfg.GenesisState[types.ModuleName], &state))
+func (suite *QueryTestSuite) TestShowVestingAccount() {
+	ctx := suite.Network.Validators[0].ClientCtx
+	accs := suite.LaunchState.VestingAccountList
 
-	for i := 0; i < n; i++ {
-		state.VestingAccountList = append(
-			state.VestingAccountList,
-			sample.VestingAccount(r, 0, strconv.Itoa(i)),
-		)
-	}
-	buf, err := cfg.Codec.MarshalJSON(&state)
-	require.NoError(t, err)
-	cfg.GenesisState[types.ModuleName] = buf
-	return network.New(t, cfg), state.VestingAccountList
-}
-
-func TestShowVestingAccount(t *testing.T) {
-	net, objs := networkWithVestingAccountObjects(t, 2)
-
-	ctx := net.Validators[0].ClientCtx
 	common := []string{
 		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
 	}
@@ -55,11 +34,11 @@ func TestShowVestingAccount(t *testing.T) {
 	}{
 		{
 			desc:      "found",
-			idChainID: strconv.Itoa(int(objs[0].LaunchID)),
-			idAddress: objs[0].Address,
+			idChainID: strconv.Itoa(int(accs[0].LaunchID)),
+			idAddress: accs[0].Address,
 
 			args: common,
-			obj:  objs[0],
+			obj:  accs[0],
 		},
 		{
 			desc:      "not found",
@@ -70,7 +49,7 @@ func TestShowVestingAccount(t *testing.T) {
 			err:  status.Error(codes.NotFound, "not found"),
 		},
 	} {
-		t.Run(tc.desc, func(t *testing.T) {
+		suite.T().Run(tc.desc, func(t *testing.T) {
 			args := []string{
 				tc.idChainID,
 				tc.idAddress,
@@ -84,7 +63,7 @@ func TestShowVestingAccount(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				var resp types.QueryGetVestingAccountResponse
-				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.NoError(t, suite.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 				require.NotNil(t, resp.VestingAccount)
 				require.Equal(t, tc.obj, resp.VestingAccount)
 			}
@@ -92,11 +71,11 @@ func TestShowVestingAccount(t *testing.T) {
 	}
 }
 
-func TestListVestingAccount(t *testing.T) {
-	net, objs := networkWithVestingAccountObjects(t, 5)
+func (suite *QueryTestSuite) TestListVestingAccount() {
+	ctx := suite.Network.Validators[0].ClientCtx
+	accs := suite.LaunchState.VestingAccountList
 
-	chainID := strconv.Itoa(int(objs[0].LaunchID))
-	ctx := net.Validators[0].ClientCtx
+	chainID := strconv.Itoa(int(accs[0].LaunchID))
 	request := func(chainID string, next []byte, offset, limit uint64, total bool) []string {
 		args := []string{
 			chainID,
@@ -113,40 +92,40 @@ func TestListVestingAccount(t *testing.T) {
 		}
 		return args
 	}
-	t.Run("ByOffset", func(t *testing.T) {
+	suite.T().Run("ByOffset", func(t *testing.T) {
 		step := 2
-		for i := 0; i < len(objs); i += step {
+		for i := 0; i < len(accs); i += step {
 			args := request(chainID, nil, uint64(i), uint64(step), false)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListVestingAccount(), args)
 			require.NoError(t, err)
 			var resp types.QueryAllVestingAccountResponse
-			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, suite.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.VestingAccount), step)
-			require.Subset(t, objs, resp.VestingAccount)
+			require.Subset(t, accs, resp.VestingAccount)
 		}
 	})
-	t.Run("ByKey", func(t *testing.T) {
+	suite.T().Run("ByKey", func(t *testing.T) {
 		step := 2
 		var next []byte
-		for i := 0; i < len(objs); i += step {
+		for i := 0; i < len(accs); i += step {
 			args := request(chainID, next, 0, uint64(step), false)
 			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListVestingAccount(), args)
 			require.NoError(t, err)
 			var resp types.QueryAllVestingAccountResponse
-			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.NoError(t, suite.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			require.LessOrEqual(t, len(resp.VestingAccount), step)
-			require.Subset(t, objs, resp.VestingAccount)
+			require.Subset(t, accs, resp.VestingAccount)
 			next = resp.Pagination.NextKey
 		}
 	})
-	t.Run("Total", func(t *testing.T) {
-		args := request(chainID, nil, 0, uint64(len(objs)), true)
+	suite.T().Run("Total", func(t *testing.T) {
+		args := request(chainID, nil, 0, uint64(len(accs)), true)
 		out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListVestingAccount(), args)
 		require.NoError(t, err)
 		var resp types.QueryAllVestingAccountResponse
-		require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+		require.NoError(t, suite.Network.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 		require.NoError(t, err)
-		require.Equal(t, len(objs), int(resp.Pagination.Total))
-		require.ElementsMatch(t, objs, resp.VestingAccount)
+		require.Equal(t, len(accs), int(resp.Pagination.Total))
+		require.ElementsMatch(t, accs, resp.VestingAccount)
 	})
 }


### PR DESCRIPTION
Implement a test suite for the query tests where a single local network instance is created for each module (instead of one network per tests)

Hopefully this implementation solve unit test issue https://github.com/tendermint/spn/issues/484