### PR TITLE
fix(`campaign`): add error in `IsTotalSharesReached`

### DIFF
--- a/x/campaign/keeper/msg_add_shares.go
+++ b/x/campaign/keeper/msg_add_shares.go
@@ -58,7 +58,11 @@ func (k msgServer) AddShares(goCtx context.Context, msg *types.MsgAddShares) (*t
 
 	// increase the campaign shares
 	campaign.AllocatedShares = types.IncreaseShares(campaign.AllocatedShares, msg.Shares)
-	if types.IsTotalSharesReached(campaign.AllocatedShares, k.GetTotalShares(ctx)) {
+	reached, err := types.IsTotalSharesReached(campaign.AllocatedShares, k.GetTotalShares(ctx))
+	if err != nil {
+		return nil, spnerrors.Criticalf("verified shares are invalid %s", err.Error())
+	}
+	if reached {
 		return nil, sdkerrors.Wrapf(types.ErrTotalSharesLimit, "%d", msg.CampaignID)
 	}
 

--- a/x/campaign/keeper/msg_add_vesting_options.go
+++ b/x/campaign/keeper/msg_add_vesting_options.go
@@ -75,7 +75,11 @@ func (k msgServer) AddVestingOptions(goCtx context.Context, msg *types.MsgAddVes
 
 	// increase the campaign shares
 	campaign.AllocatedShares = types.IncreaseShares(campaign.AllocatedShares, totalShares)
-	if types.IsTotalSharesReached(campaign.AllocatedShares, k.GetTotalShares(ctx)) {
+	reached, err := types.IsTotalSharesReached(campaign.AllocatedShares, k.GetTotalShares(ctx))
+	if err != nil {
+		return nil, spnerrors.Criticalf("verified shares are invalid %s", err.Error())
+	}
+	if reached {
 		return nil, sdkerrors.Wrapf(types.ErrTotalSharesLimit, "%d", msg.CampaignID)
 	}
 

--- a/x/campaign/keeper/msg_mint_vouchers.go
+++ b/x/campaign/keeper/msg_mint_vouchers.go
@@ -35,7 +35,11 @@ func (k msgServer) MintVouchers(goCtx context.Context, msg *types.MsgMintVoucher
 
 	// Increase the campaign shares
 	campaign.AllocatedShares = types.IncreaseShares(campaign.AllocatedShares, msg.Shares)
-	if types.IsTotalSharesReached(campaign.AllocatedShares, k.GetTotalShares(ctx)) {
+	reached, err := types.IsTotalSharesReached(campaign.AllocatedShares, k.GetTotalShares(ctx))
+	if err != nil {
+		return nil, spnerrors.Criticalf("verified shares are invalid %s", err.Error())
+	}
+	if reached {
 		return nil, sdkerrors.Wrapf(types.ErrTotalSharesLimit, "%d", msg.CampaignID)
 	}
 

--- a/x/campaign/types/campaign.go
+++ b/x/campaign/types/campaign.go
@@ -1,10 +1,10 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -33,12 +33,12 @@ func (m Campaign) Validate(totalShareNumber uint64) error {
 	if !m.TotalSupply.IsValid() {
 		return errors.New("invalid total supply")
 	}
-	if !sdk.Coins(m.AllocatedShares).IsValid() {
-		return errors.New("invalid allocated shares")
+
+	reached, err := IsTotalSharesReached(m.AllocatedShares, totalShareNumber)
+	if err != nil {
+		return errors.Wrap(err, "invalid allocated shares")
 	}
-
-	if IsTotalSharesReached(m.AllocatedShares, totalShareNumber) {
-
+	if reached {
 		return errors.New("more allocated shares than total shares")
 	}
 

--- a/x/campaign/types/campaign_test.go
+++ b/x/campaign/types/campaign_test.go
@@ -43,7 +43,9 @@ func TestCampaign_Validate(t *testing.T) {
 	totalSharesReached.AllocatedShares = campaign.NewSharesFromCoins(sdk.NewCoins(
 		sdk.NewCoin("foo", sdk.NewInt(spntypes.TotalShareNumber+1)),
 	))
-	require.True(t, campaign.IsTotalSharesReached(totalSharesReached.AllocatedShares, spntypes.TotalShareNumber))
+	reached, err := campaign.IsTotalSharesReached(totalSharesReached.AllocatedShares, spntypes.TotalShareNumber)
+	require.NoError(t, err)
+	require.True(t, reached)
 
 	for _, tc := range []struct {
 		desc     string

--- a/x/campaign/types/shares.go
+++ b/x/campaign/types/shares.go
@@ -1,11 +1,11 @@
 package types
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/pkg/errors"
 )
 
 // Shares represents the portion of a supply
@@ -73,14 +73,21 @@ func DecreaseShares(shares, toDecrease Shares) (Shares, error) {
 }
 
 // IsTotalSharesReached checks if the provided shares overflow the total number of shares
-func IsTotalSharesReached(shares Shares, maximumTotalShareNumber uint64) bool {
+func IsTotalSharesReached(shares Shares, maximumTotalShareNumber uint64) (bool, error) {
+	if err := sdk.Coins(shares).Validate(); err != nil {
+		return false, errors.Wrap(err, "invalid share")
+	}
+	if err := CheckShares(shares); err != nil {
+		return false, errors.Wrap(err, "invalid share format")
+	}
+
 	for _, coin := range shares {
 		if coin.Amount.Uint64() > maximumTotalShareNumber {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // IsAllLTE returns true iff for every denom in shares, the denom is present at

--- a/x/campaign/types/shares_test.go
+++ b/x/campaign/types/shares_test.go
@@ -125,28 +125,61 @@ func TestDecreaseShares(t *testing.T) {
 
 func TestShareIsTotalReached(t *testing.T) {
 	for _, tc := range []struct {
-		desc    string
-		shares  campaign.Shares
-		reached bool
+		desc           string
+		shares         campaign.Shares
+		maxTotalShares uint64
+		reached        bool
+		isValid        bool
 	}{
 		{
-			desc:    "empty is false",
-			shares:  campaign.EmptyShares(),
-			reached: false,
+			desc:           "should return false with empty shares",
+			shares:         campaign.EmptyShares(),
+			maxTotalShares: 0,
+			reached:        false,
+			isValid:        true,
 		},
 		{
-			desc:    "no default total is reached",
-			shares:  tc.Shares(t, fmt.Sprintf("%dfoo,100bar", spntypes.TotalShareNumber)),
-			reached: false,
+			desc:           "should return false when total not reached",
+			shares:         tc.Shares(t, "1000foo,100bar"),
+			maxTotalShares: 1000,
+			reached:        false,
+			isValid:        true,
 		},
 		{
-			desc:    "a default total is reached",
-			shares:  tc.Shares(t, fmt.Sprintf("%dfoo,100bar", spntypes.TotalShareNumber+1)),
-			reached: true,
+			desc:           "should return true when total reached",
+			shares:         tc.Shares(t, "1001foo,100bar"),
+			maxTotalShares: 1000,
+			reached:        true,
+			isValid:        true,
+		},
+		{
+			desc: "should return error if shares are invalid",
+			shares: campaign.NewSharesFromCoins(sdk.Coins{
+				sdk.NewCoin("foo", sdk.NewIntFromUint64(500)),
+				sdk.NewCoin("foo", sdk.NewIntFromUint64(500)),
+			}),
+			maxTotalShares: 1000,
+			reached:        false,
+			isValid:        false,
+		},
+		{
+			desc: "should return error if shares have invalid format",
+			shares: campaign.Shares(sdk.Coins{
+				sdk.NewCoin("foo", sdk.NewIntFromUint64(500)),
+			}),
+			maxTotalShares: 1000,
+			reached:        false,
+			isValid:        false,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			require.Equal(t, tc.reached, campaign.IsTotalSharesReached(tc.shares, spntypes.TotalShareNumber))
+			reached, err := campaign.IsTotalSharesReached(tc.shares, tc.maxTotalShares)
+			if tc.isValid {
+				require.NoError(t, err)
+				require.True(t, tc.reached == reached)
+			} else {
+				require.Error(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Add error in `IsTotalSharesReached` in case provided shares are not valid (ex: duplicate denoms)