### PR TITLE
fix(`monitoringc`): fix `RegisterProviderClientIDFromChannelID` description

### DIFF
--- a/x/monitoringc/keeper/handshake.go
+++ b/x/monitoringc/keeper/handshake.go
@@ -44,8 +44,8 @@ func (k Keeper) RegisterProviderClientIDFromChannelID(ctx sdk.Context, channelID
 	clientID, err := k.getClientIDFromChannelID(ctx, channelID)
 	if err != nil {
 		return spnerrors.Criticalf(
-			"client ID %s should be retrieved during registration, got error: %s",
-			clientID,
+			"client ID should be retrieved from channel ID %s during registration, got error: %s",
+			channelID,
 			err.Error(),
 		)
 	}


### PR DESCRIPTION
Remove `clientID` from the error description since this value is not set when returned in the method. Change the error to describe a client ID is not found from the channel ID
