### PR TITLE
refactor: factorize similar store key methods

### DIFF
--- a/x/campaign/keeper/mainnet_account.go
+++ b/x/campaign/keeper/mainnet_account.go
@@ -11,7 +11,7 @@ import (
 func (k Keeper) SetMainnetAccount(ctx sdk.Context, mainnetAccount types.MainnetAccount) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.MainnetAccountKeyPrefix))
 	b := k.cdc.MustMarshal(&mainnetAccount)
-	store.Set(types.MainnetAccountKey(
+	store.Set(types.AccountKeyPath(
 		mainnetAccount.CampaignID,
 		mainnetAccount.Address,
 	), b)
@@ -25,7 +25,7 @@ func (k Keeper) GetMainnetAccount(
 ) (val types.MainnetAccount, found bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.MainnetAccountKeyPrefix))
 
-	b := store.Get(types.MainnetAccountKey(campaignID, address))
+	b := store.Get(types.AccountKeyPath(campaignID, address))
 	if b == nil {
 		return val, false
 	}
@@ -41,7 +41,7 @@ func (k Keeper) RemoveMainnetAccount(
 	address string,
 ) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.MainnetAccountKeyPrefix))
-	store.Delete(types.MainnetAccountKey(
+	store.Delete(types.AccountKeyPath(
 		campaignID,
 		address,
 	))

--- a/x/campaign/keeper/mainnet_vesting_account.go
+++ b/x/campaign/keeper/mainnet_vesting_account.go
@@ -11,7 +11,7 @@ import (
 func (k Keeper) SetMainnetVestingAccount(ctx sdk.Context, mainnetVestingAccount types.MainnetVestingAccount) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.MainnetVestingAccountKeyPrefix))
 	b := k.cdc.MustMarshal(&mainnetVestingAccount)
-	store.Set(types.MainnetVestingAccountKey(
+	store.Set(types.AccountKeyPath(
 		mainnetVestingAccount.CampaignID,
 		mainnetVestingAccount.Address,
 	), b)
@@ -25,7 +25,7 @@ func (k Keeper) GetMainnetVestingAccount(
 ) (val types.MainnetVestingAccount, found bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.MainnetVestingAccountKeyPrefix))
 
-	b := store.Get(types.MainnetVestingAccountKey(campaignID, address))
+	b := store.Get(types.AccountKeyPath(campaignID, address))
 	if b == nil {
 		return val, false
 	}
@@ -41,7 +41,7 @@ func (k Keeper) RemoveMainnetVestingAccount(
 	address string,
 ) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.MainnetVestingAccountKeyPrefix))
-	store.Delete(types.MainnetVestingAccountKey(campaignID, address))
+	store.Delete(types.AccountKeyPath(campaignID, address))
 }
 
 // GetAllMainnetVestingAccount returns all mainnetVestingAccount

--- a/x/campaign/types/genesis.go
+++ b/x/campaign/types/genesis.go
@@ -59,7 +59,7 @@ func (gs GenesisState) Validate() error {
 			return fmt.Errorf("campaign id %d doesn't exist for mainnet account %s",
 				elem.CampaignID, elem.Address)
 		}
-		index := string(MainnetAccountKey(elem.CampaignID, elem.Address))
+		index := string(AccountKeyPath(elem.CampaignID, elem.Address))
 		if _, ok := mainnetAccountIndexMap[index]; ok {
 			return fmt.Errorf("duplicated index for mainnetAccount")
 		}
@@ -73,7 +73,7 @@ func (gs GenesisState) Validate() error {
 			return fmt.Errorf("campaign id %d doesn't exist for mainnet vesting account %s",
 				elem.CampaignID, elem.Address)
 		}
-		index := string(MainnetVestingAccountKey(elem.CampaignID, elem.Address))
+		index := string(AccountKeyPath(elem.CampaignID, elem.Address))
 		if _, ok := mainnetVestingAccountIndexMap[index]; ok {
 			return fmt.Errorf("duplicated index for mainnetVestingAccount")
 		}

--- a/x/campaign/types/keys.go
+++ b/x/campaign/types/keys.go
@@ -46,8 +46,8 @@ func CampaignChainsKey(campaignID uint64) []byte {
 	return append(spntypes.UintBytes(campaignID), byte('/'))
 }
 
-// MainnetAccountKey returns the store key to retrieve a MainnetAccount from the index fields
-func MainnetAccountKey(campaignID uint64, address string) []byte {
+// AccountKeyPath returns the store key path without prefix for an account defined by a campaign ID and an address
+func AccountKeyPath(campaignID uint64, address string) []byte {
 	campaignIDBytes := append(spntypes.UintBytes(campaignID), byte('/'))
 	addressBytes := append([]byte(address), byte('/'))
 	return append(campaignIDBytes, addressBytes...)
@@ -58,13 +58,6 @@ func MainnetAccountAllKey(campaignID uint64) []byte {
 	prefixBytes := []byte(MainnetAccountKeyPrefix)
 	campaignIDBytes := append(spntypes.UintBytes(campaignID), byte('/'))
 	return append(prefixBytes, campaignIDBytes...)
-}
-
-// MainnetVestingAccountKey returns the store key to retrieve a MainnetVestingAccount from the index fields
-func MainnetVestingAccountKey(campaignID uint64, address string) []byte {
-	campaignIDBytes := append(spntypes.UintBytes(campaignID), byte('/'))
-	addressBytes := append([]byte(address), byte('/'))
-	return append(campaignIDBytes, addressBytes...)
 }
 
 // MainnetVestingAccountAllKey returns the store key to retrieve all MainnetVestingAccount by campaign id

--- a/x/launch/keeper/genesis_account.go
+++ b/x/launch/keeper/genesis_account.go
@@ -11,7 +11,7 @@ import (
 func (k Keeper) SetGenesisAccount(ctx sdk.Context, genesisAccount types.GenesisAccount) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.GenesisAccountKeyPrefix))
 	b := k.cdc.MustMarshal(&genesisAccount)
-	store.Set(types.GenesisAccountKey(
+	store.Set(types.AccountKeyPath(
 		genesisAccount.LaunchID,
 		genesisAccount.Address,
 	), b)
@@ -25,7 +25,7 @@ func (k Keeper) GetGenesisAccount(
 ) (val types.GenesisAccount, found bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.GenesisAccountKeyPrefix))
 
-	b := store.Get(types.GenesisAccountKey(launchID, address))
+	b := store.Get(types.AccountKeyPath(launchID, address))
 	if b == nil {
 		return val, false
 	}
@@ -41,7 +41,7 @@ func (k Keeper) RemoveGenesisAccount(
 	address string,
 ) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.GenesisAccountKeyPrefix))
-	store.Delete(types.GenesisAccountKey(launchID, address))
+	store.Delete(types.AccountKeyPath(launchID, address))
 }
 
 // GetAllGenesisAccount returns all genesisAccount

--- a/x/launch/keeper/genesis_validator.go
+++ b/x/launch/keeper/genesis_validator.go
@@ -13,7 +13,7 @@ import (
 func (k Keeper) SetGenesisValidator(ctx sdk.Context, genesisValidator types.GenesisValidator) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.GenesisValidatorKeyPrefix))
 	b := k.cdc.MustMarshal(&genesisValidator)
-	store.Set(types.GenesisValidatorKey(
+	store.Set(types.AccountKeyPath(
 		genesisValidator.LaunchID,
 		genesisValidator.Address,
 	), b)
@@ -27,7 +27,7 @@ func (k Keeper) GetGenesisValidator(
 ) (val types.GenesisValidator, found bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.GenesisValidatorKeyPrefix))
 
-	b := store.Get(types.GenesisValidatorKey(launchID, address))
+	b := store.Get(types.AccountKeyPath(launchID, address))
 	if b == nil {
 		return val, false
 	}
@@ -53,7 +53,7 @@ func (k Keeper) GetGenesisValidatorCount(ctx sdk.Context, launchID uint64) (coun
 // RemoveGenesisValidator removes a genesisValidator from the store
 func (k Keeper) RemoveGenesisValidator(ctx sdk.Context, launchID uint64, address string) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.GenesisValidatorKeyPrefix))
-	store.Delete(types.GenesisValidatorKey(launchID, address))
+	store.Delete(types.AccountKeyPath(launchID, address))
 }
 
 // GetAllGenesisValidator returns all genesisValidator

--- a/x/launch/keeper/vesting_account.go
+++ b/x/launch/keeper/vesting_account.go
@@ -11,7 +11,7 @@ import (
 func (k Keeper) SetVestingAccount(ctx sdk.Context, vestingAccount types.VestingAccount) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.VestingAccountKeyPrefix))
 	b := k.cdc.MustMarshal(&vestingAccount)
-	store.Set(types.VestingAccountKey(
+	store.Set(types.AccountKeyPath(
 		vestingAccount.LaunchID,
 		vestingAccount.Address,
 	), b)
@@ -25,7 +25,7 @@ func (k Keeper) GetVestingAccount(
 ) (val types.VestingAccount, found bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.VestingAccountKeyPrefix))
 
-	b := store.Get(types.VestingAccountKey(launchID, address))
+	b := store.Get(types.AccountKeyPath(launchID, address))
 	if b == nil {
 		return val, false
 	}
@@ -41,7 +41,7 @@ func (k Keeper) RemoveVestingAccount(
 	address string,
 ) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.VestingAccountKeyPrefix))
-	store.Delete(types.VestingAccountKey(launchID, address))
+	store.Delete(types.AccountKeyPath(launchID, address))
 }
 
 // GetAllVestingAccount returns all vestingAccount

--- a/x/launch/types/genesis.go
+++ b/x/launch/types/genesis.go
@@ -117,7 +117,7 @@ func validateAccounts(gs GenesisState, launchIDMap map[uint64]struct{}) error {
 	// Check for duplicated index in genesisAccount
 	genesisAccountIndexMap := make(map[string]struct{})
 	for _, elem := range gs.GenesisAccountList {
-		index := string(GenesisAccountKey(elem.LaunchID, elem.Address))
+		index := string(AccountKeyPath(elem.LaunchID, elem.Address))
 		if _, ok := genesisAccountIndexMap[index]; ok {
 			return fmt.Errorf("duplicated index for genesisAccount")
 		}
@@ -135,7 +135,7 @@ func validateAccounts(gs GenesisState, launchIDMap map[uint64]struct{}) error {
 	// Check for duplicated index in vestingAccount
 	vestingAccountIndexMap := make(map[string]struct{})
 	for _, elem := range gs.VestingAccountList {
-		index := string(VestingAccountKey(elem.LaunchID, elem.Address))
+		index := string(AccountKeyPath(elem.LaunchID, elem.Address))
 		if _, ok := vestingAccountIndexMap[index]; ok {
 			return fmt.Errorf("duplicated index for vestingAccount")
 		}
@@ -150,7 +150,7 @@ func validateAccounts(gs GenesisState, launchIDMap map[uint64]struct{}) error {
 		}
 
 		// An address cannot be defined as a genesis account and a vesting account for the same chain
-		accountIndex := GenesisAccountKey(elem.LaunchID, elem.Address)
+		accountIndex := AccountKeyPath(elem.LaunchID, elem.Address)
 		if _, ok := genesisAccountIndexMap[string(accountIndex)]; ok {
 			return fmt.Errorf("account %s can't be a genesis account and a vesting account at the same time for the chain: %d",
 				elem.Address,
@@ -162,7 +162,7 @@ func validateAccounts(gs GenesisState, launchIDMap map[uint64]struct{}) error {
 	// Check for duplicated index in genesisValidator
 	genesisValidatorIndexMap := make(map[string]struct{})
 	for _, elem := range gs.GenesisValidatorList {
-		index := string(GenesisValidatorKey(elem.LaunchID, elem.Address))
+		index := string(AccountKeyPath(elem.LaunchID, elem.Address))
 		if _, ok := genesisValidatorIndexMap[index]; ok {
 			return fmt.Errorf("duplicated index for genesisValidator")
 		}

--- a/x/launch/types/keys.go
+++ b/x/launch/types/keys.go
@@ -49,8 +49,8 @@ func ChainKey(launchID uint64) []byte {
 	return append(spntypes.UintBytes(launchID), byte('/'))
 }
 
-// GenesisAccountKey returns the store key to retrieve a GenesisAccount from the index fields
-func GenesisAccountKey(launchID uint64, address string) []byte {
+// AccountKeyPath returns the store key path with prefix for an account defined by a launch ID and an address
+func AccountKeyPath(launchID uint64, address string) []byte {
 	launchIDBytes := append(spntypes.UintBytes(launchID), byte('/'))
 	addressBytes := append([]byte(address), byte('/'))
 	return append(launchIDBytes, addressBytes...)
@@ -63,25 +63,11 @@ func GenesisAccountAllKey(launchID uint64) []byte {
 	return append(prefixBytes, launchIDBytes...)
 }
 
-// VestingAccountKey returns the store key to retrieve a VestingAccount from the index fields
-func VestingAccountKey(launchID uint64, address string) []byte {
-	launchIDBytes := append(spntypes.UintBytes(launchID), byte('/'))
-	addressBytes := append([]byte(address), byte('/'))
-	return append(launchIDBytes, addressBytes...)
-}
-
 // VestingAccountAllKey returns the store key to retrieve all VestingAccount by launchID
 func VestingAccountAllKey(launchID uint64) []byte {
 	prefixBytes := []byte(VestingAccountKeyPrefix)
 	launchIDBytes := append(spntypes.UintBytes(launchID), byte('/'))
 	return append(prefixBytes, launchIDBytes...)
-}
-
-// GenesisValidatorKey returns the store key to retrieve a GenesisValidator from the index fields
-func GenesisValidatorKey(launchID uint64, address string) []byte {
-	launchIDBytes := append(spntypes.UintBytes(launchID), byte('/'))
-	addressBytes := append([]byte(address), byte('/'))
-	return append(launchIDBytes, addressBytes...)
 }
 
 // GenesisValidatorAllKey returns the store key to retrieve all GenesisValidator by launchID

--- a/x/launch/types/keys.go
+++ b/x/launch/types/keys.go
@@ -49,7 +49,7 @@ func ChainKey(launchID uint64) []byte {
 	return append(spntypes.UintBytes(launchID), byte('/'))
 }
 
-// AccountKeyPath returns the store key path with prefix for an account defined by a launch ID and an address
+// AccountKeyPath returns the store key path without prefix for an account defined by a launch ID and an address
 func AccountKeyPath(launchID uint64, address string) []byte {
 	launchIDBytes := append(spntypes.UintBytes(launchID), byte('/'))
 	addressBytes := append([]byte(address), byte('/'))


### PR DESCRIPTION
Factorize different methods with similar logic in `key.go` to retrieve account key path.

Unique method is named `AccountKeyPath`
