### PR TITLE
fix: app.go const lint

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -127,11 +127,11 @@ import (
 )
 
 const (
-	// mission ID for staking mission to claim airdrop
-	MISSION_ID_STAKING = 1
+	// MissionIdStaking is the mission ID for staking mission to claim airdrop
+	MissionIdStaking = 1
 
-	// mission ID for voting mission to claim airdrop
-	MISSION_ID_VOTING = 2
+	// MissionIdVoting is the mission ID for voting mission to claim airdrop
+	MissionIdVoting = 2
 )
 
 // this line is used by starport scaffolding # stargate/wasm/app/enabledProposals
@@ -543,14 +543,14 @@ func New(
 		stakingtypes.NewMultiStakingHooks(
 			app.DistrKeeper.Hooks(),
 			app.SlashingKeeper.Hooks(),
-			app.ClaimKeeper.NewMissionDelegationHooks(MISSION_ID_STAKING),
+			app.ClaimKeeper.NewMissionDelegationHooks(MissionIdStaking),
 		),
 	)
 
 	// register the gov hooks
 	app.GovKeeper = *app.GovKeeper.SetHooks(
 		govtypes.NewMultiGovHooks(
-			app.ClaimKeeper.NewMissionVoteHooks(MISSION_ID_VOTING),
+			app.ClaimKeeper.NewMissionVoteHooks(MissionIdVoting),
 		),
 	)
 

--- a/app/app.go
+++ b/app/app.go
@@ -127,10 +127,10 @@ import (
 )
 
 const (
-	// missionIdStaking is the mission ID for staking mission to claim airdrop
+	// missionIDStaking is the mission ID for staking mission to claim airdrop
 	missionIDStaking = 1
 
-	// missionIdVoting is the mission ID for voting mission to claim airdrop
+	// missionIDVoting is the mission ID for voting mission to claim airdrop
 	missionIDVoting = 2
 )
 

--- a/app/app.go
+++ b/app/app.go
@@ -127,11 +127,11 @@ import (
 )
 
 const (
-	// MissionIdStaking is the mission ID for staking mission to claim airdrop
-	MissionIdStaking = 1
+	// missionIdStaking is the mission ID for staking mission to claim airdrop
+	missionIdStaking = 1
 
-	// MissionIdVoting is the mission ID for voting mission to claim airdrop
-	MissionIdVoting = 2
+	// missionIdVoting is the mission ID for voting mission to claim airdrop
+	missionIdVoting = 2
 )
 
 // this line is used by starport scaffolding # stargate/wasm/app/enabledProposals
@@ -543,14 +543,14 @@ func New(
 		stakingtypes.NewMultiStakingHooks(
 			app.DistrKeeper.Hooks(),
 			app.SlashingKeeper.Hooks(),
-			app.ClaimKeeper.NewMissionDelegationHooks(MissionIdStaking),
+			app.ClaimKeeper.NewMissionDelegationHooks(missionIdStaking),
 		),
 	)
 
 	// register the gov hooks
 	app.GovKeeper = *app.GovKeeper.SetHooks(
 		govtypes.NewMultiGovHooks(
-			app.ClaimKeeper.NewMissionVoteHooks(MissionIdVoting),
+			app.ClaimKeeper.NewMissionVoteHooks(missionIdVoting),
 		),
 	)
 

--- a/app/app.go
+++ b/app/app.go
@@ -128,10 +128,10 @@ import (
 
 const (
 	// missionIdStaking is the mission ID for staking mission to claim airdrop
-	missionIdStaking = 1
+	missionIDStaking = 1
 
 	// missionIdVoting is the mission ID for voting mission to claim airdrop
-	missionIdVoting = 2
+	missionIDVoting = 2
 )
 
 // this line is used by starport scaffolding # stargate/wasm/app/enabledProposals
@@ -543,14 +543,14 @@ func New(
 		stakingtypes.NewMultiStakingHooks(
 			app.DistrKeeper.Hooks(),
 			app.SlashingKeeper.Hooks(),
-			app.ClaimKeeper.NewMissionDelegationHooks(missionIdStaking),
+			app.ClaimKeeper.NewMissionDelegationHooks(missionIDStaking),
 		),
 	)
 
 	// register the gov hooks
 	app.GovKeeper = *app.GovKeeper.SetHooks(
 		govtypes.NewMultiGovHooks(
-			app.ClaimKeeper.NewMissionVoteHooks(missionIdVoting),
+			app.ClaimKeeper.NewMissionVoteHooks(missionIDVoting),
 		),
 	)
 


### PR DESCRIPTION
Fix lint error based on cosntant name format in `app.go`
