### PR TITLE
refactor: remove usage of `ToDec()`

### DIFF
--- a/x/claim/types/claim_record.go
+++ b/x/claim/types/claim_record.go
@@ -40,5 +40,5 @@ func (m ClaimRecord) IsMissionCompleted(missionID uint64) bool {
 
 // ClaimableFromMission returns the amount claimable for this claim record from the provided mission completion
 func (m ClaimRecord) ClaimableFromMission(mission Mission) sdk.Int {
-	return mission.Weight.Mul(m.Claimable.ToDec()).TruncateInt()
+	return mission.Weight.Mul(sdk.NewDecFromInt(m.Claimable)).TruncateInt()
 }

--- a/x/launch/keeper/genesis_validator.go
+++ b/x/launch/keeper/genesis_validator.go
@@ -76,7 +76,7 @@ func (k Keeper) GetValidatorsAndTotalDelegation(
 		k.cdc.MustUnmarshal(iterator.Value(), &val)
 		consPubKey := base64.StdEncoding.EncodeToString(val.ConsPubKey)
 		validators[consPubKey] = val
-		totalDelegation = totalDelegation.Add(val.SelfDelegation.Amount.ToDec())
+		totalDelegation = totalDelegation.Add(sdk.NewDecFromInt(val.SelfDelegation.Amount))
 	}
 	return validators, totalDelegation
 }

--- a/x/launch/keeper/genesis_validator_test.go
+++ b/x/launch/keeper/genesis_validator_test.go
@@ -86,7 +86,7 @@ func TestKeeper_GetValidatorsAndTotalDelegation(t *testing.T) {
 	for _, validator := range validators {
 		consPubKey := base64.StdEncoding.EncodeToString(validator.ConsPubKey)
 		validatorMap[consPubKey] = validator
-		totalSelfDelegation = totalSelfDelegation.Add(validator.SelfDelegation.Amount.ToDec())
+		totalSelfDelegation = totalSelfDelegation.Add(sdk.NewDecFromInt(validator.SelfDelegation.Amount))
 	}
 
 	t.Run("should get a map of genesis validator and the total delegation", func(t *testing.T) {

--- a/x/launch/keeper/validator_set.go
+++ b/x/launch/keeper/validator_set.go
@@ -49,7 +49,7 @@ func (k Keeper) CheckValidatorSet(
 				validator.PubKey.Address().String(),
 			)
 		}
-		valSetSelfDelegation = valSetSelfDelegation.Add(launchValidator.SelfDelegation.Amount.ToDec())
+		valSetSelfDelegation = valSetSelfDelegation.Add(sdk.NewDecFromInt(launchValidator.SelfDelegation.Amount))
 	}
 
 	// check if 2/3 of total self-delegation is reached from the provided validator set

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -117,7 +117,7 @@ func (k Keeper) AddCollectedFees(ctx sdk.Context, fees sdk.Coins) error {
 
 // GetProportions gets the balance of the `MintedDenom` from minted coins and returns coins according to the `AllocationRatio`.
 func (k Keeper) GetProportions(ctx sdk.Context, mintedCoin sdk.Coin, ratio sdk.Dec) sdk.Coin {
-	return sdk.NewCoin(mintedCoin.Denom, mintedCoin.Amount.ToDec().Mul(ratio).TruncateInt())
+	return sdk.NewCoin(mintedCoin.Denom, sdk.NewDecFromInt(mintedCoin.Amount).Mul(ratio).TruncateInt())
 }
 
 // DistributeMintedCoins implements distribution of minted coins from mint

--- a/x/participation/keeper/total_allocations.go
+++ b/x/participation/keeper/total_allocations.go
@@ -11,7 +11,7 @@ import (
 
 // GetTotalAllocations returns the number of available allocations based on delegations
 func (k Keeper) GetTotalAllocations(ctx sdk.Context, address string) (uint64, error) {
-	allocationPriceBondedDec := k.AllocationPrice(ctx).Bonded.ToDec()
+	allocationPriceBondedDec := sdk.NewDecFromInt(k.AllocationPrice(ctx).Bonded)
 
 	accAddr, err := sdk.AccAddressFromBech32(address)
 	if err != nil {

--- a/x/reward/keeper/reward_distribution.go
+++ b/x/reward/keeper/reward_distribution.go
@@ -202,7 +202,7 @@ func CalculateRewards(blockRatio, signatureRatio sdk.Dec, coins sdk.Coins) (sdk.
 	// calculate rewards
 	rewards := sdk.NewCoins()
 	for _, coin := range coins {
-		amount := blockRatio.Mul(signatureRatio).Mul(coin.Amount.ToDec())
+		amount := blockRatio.Mul(signatureRatio).Mul(sdk.NewDecFromInt(coin.Amount))
 		coin.Amount = amount.TruncateInt()
 		rewards = rewards.Add(coin)
 	}


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

### What does this PR does?

Remove all uses of the `sdk.Int.ToDec()` function.  This function is removed in SDK `v0.46.0`.  Conversion between `sdk.Int` and `sdk.Dec` can be done using `sdk.NewDecFromInt()`.

Part of #909

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Include tests
- [ ] Respect code style and lint
- [ ] Update documentation (*.md) (if needed)
