### PR TITLE
chore: set binary name in config_2.yml

### DIFF
--- a/config_2.yml
+++ b/config_2.yml
@@ -50,4 +50,5 @@ host:
   grpc: ":9094"
   grpc-web: ":9095"
   api: ":1319"
-  
+build:
+  binary: "spn2d"


### PR DESCRIPTION
Set custom binary name in `config_2.yml` to make usage of local `spn` working when launching `spn`

The reason for this is that the local `spn` instance and the `spn` to launch could have different versions

If cli interface is not compatible, usage of network command fails because the `spnd` command from the `spn` to launch built binary will be run with the incompatible keyring of the `spn` instance 