### PR TITLE
chore: remove `io/ioutil`

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -49,7 +49,8 @@ func (app *App) ExportAppStateAndValidators(
 
 // prepare for fresh start at zero height
 // NOTE zero height genesis is a temporary feature which will be deprecated
-//      in favour of export at a block height
+//
+//	in favour of export at a block height
 func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
 	applyAllowedAddrs := false
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3,5 +3,6 @@ package docs
 import "embed"
 
 // Docs represents the embedded doc file
+//
 //go:embed static
 var Docs embed.FS

--- a/x/launch/client/cli/tx_create_chain.go
+++ b/x/launch/client/cli/tx_create_chain.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	neturl "net/url"
@@ -117,7 +117,7 @@ func getHashFromURL(ctx context.Context, url string) (string, error) {
 	if res.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("genesis url fetch error %s", res.Status)
 	}
-	initialGenesis, err := ioutil.ReadAll(res.Body)
+	initialGenesis, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}

--- a/x/launch/client/cli/tx_request_add_validator.go
+++ b/x/launch/client/cli/tx_request_add_validator.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -31,7 +31,7 @@ func CmdRequestAddValidator() *cobra.Command {
 			}
 
 			// Read gentxFile
-			gentxBytes, err := ioutil.ReadFile(args[1])
+			gentxBytes, err := os.ReadFile(args[1])
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Removes usage of `io/ioutil` package from the codebase.  This package has been deprecated since go `1.16` and has equivalent functions in other package (namely `os` and `io`).