### PR TITLE
feat(`launch`): improve capability for chain metadata

### DIFF
--- a/pkg/types/constant.go
+++ b/pkg/types/constant.go
@@ -11,7 +11,7 @@ const (
 	DefaultChainID = "spn-1"
 
 	// MaxMetadataLength is the max length for metadata attached to chain and campaign
-	MaxMetadataLength = 100
+	MaxMetadataLength = 1000
 
 	// DefaultUnbondingPeriod is the default unbonding time in seconds
 	// 1814400 represents 21 days

--- a/scripts/metadata_sample.yml
+++ b/scripts/metadata_sample.yml
@@ -1,0 +1,8 @@
+version: alpha
+launchpad:
+  overview:
+    repository: https://github.com/ignite/example
+    path: project/description.md
+cli:
+  version:
+    release: v0.24.0

--- a/scripts/populate.sh
+++ b/scripts/populate.sh
@@ -43,7 +43,7 @@ SpndCommand "profile create-coordinator" steve
 SpndCommand "profile create-coordinator" olivia
 
 echo "creating chains..."
-SpndCommand 'launch create-chain spn-10 https://github.com/tendermint/spn.git 0xaaa' alice
+SpndCommand 'launch create-chain example-10 https://github.com/ignite/example.git 0xaaa --metadata-file scripts/metadata_sample.yml' alice
 SpndCommand 'launch create-chain mars-1 https://github.com/lubtd/planet.git 0xbbb' bob
 SpndCommand 'launch create-chain spn-11 https://github.com/tendermint/spn.git 0xccc' carol
 SpndCommand 'launch create-chain spn-11 https://github.com/tendermint/spn.git 0xccc --account-balance 10000foo' carol

--- a/x/launch/client/cli/tx_create_chain.go
+++ b/x/launch/client/cli/tx_create_chain.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	neturl "net/url"
+	"os"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -20,6 +21,7 @@ import (
 )
 
 const (
+	flagMetadataFile      = "metadata-file"
 	flagGenesisURL        = "genesis-url"
 	flagGenesisConfigFile = "genesis-config"
 	flagCampaignID        = "campaign-id"
@@ -79,11 +81,17 @@ func CmdCreateChain() *cobra.Command {
 				return errors.New("cannot use genesisURL and genesis config file")
 			}
 
-			metadata, err := cmd.Flags().GetString(flagMetadata)
-			if err != nil {
-				return err
+			var metadataBytes []byte
+			metadataFile, _ := cmd.Flags().GetString(flagMetadataFile)
+			if metadataFile != "" {
+				metadataBytes, err = os.ReadFile(metadataFile)
+				if err != nil {
+					return err
+				}
+			} else {
+				metadata, _ := cmd.Flags().GetString(flagMetadata)
+				metadataBytes = []byte(metadata)
 			}
-			metadataBytes := []byte(metadata)
 
 			balanceCoins := sdk.NewCoins()
 			balance, err := cmd.Flags().GetString(flagAccountBalance)
@@ -117,6 +125,7 @@ func CmdCreateChain() *cobra.Command {
 	}
 
 	cmd.Flags().String(flagGenesisURL, "", "URL for a custom genesis")
+	cmd.Flags().String(flagMetadataFile, "", "Set metadata for chain from file content")
 	cmd.Flags().String(flagGenesisConfigFile, "", "config file for a custom genesis")
 	cmd.Flags().Int64(flagCampaignID, -1, "The campaign id")
 	cmd.Flags().String(flagMetadata, "", "Set metadata field for the chain")


### PR DESCRIPTION
- add `metadata-file` flag to specify a file for chain metadata content in create chain command
- increase metadata max length to `1000`
- add in `populate.sh` script a chain with metadata for launchpad overview