### PR TITLE
chore: add logo and cover in sample metadata

### DIFF
--- a/scripts/metadata_sample.yml
+++ b/scripts/metadata_sample.yml
@@ -2,7 +2,9 @@ version: alpha
 launchpad:
   overview:
     repository: https://github.com/ignite/example
-    path: project/description.md
+    description: project/description.md
+    cover: project/cover.png
+    logo: project/logo.png
 cli:
   version:
     release: v0.24.0


### PR DESCRIPTION
Add the logo and cover added in `example project`
