### PR TITLE
chore: update metadata sample with new logo and cover

### DIFF
--- a/scripts/metadata_sample.yml
+++ b/scripts/metadata_sample.yml
@@ -3,8 +3,8 @@ launchpad:
   overview:
     repository: https://github.com/ignite/example
     description: project/description.md
-    cover: project/cover.png
-    logo: project/logo.png
+    cover: project/cover.jpg
+    logo: project/logo.jpg
 cli:
   version:
     release: v0.24.0


### PR DESCRIPTION
Update yet another time to support the new logo and cover extension