### PR TITLE
chore(ci/coverage): test all go packages and remove the non-testable files from coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,12 @@ jobs:
           excludelist="$(find ./ -type f -name '*.go' | xargs grep -l 'DONTCOVER')"
           excludelist+=" $(find ./ -type f -name '*.pb.go')"
           excludelist+=" $(find ./ -type f -name '*.pb.gw.go')"
+          excludelist+=" $(find ./app -type d)"
           excludelist+=" $(find ./cmd -type d)"
-          excludelist+=" $(find ./tests -type d)"
+          excludelist+=" $(find ./docs -type d)"
+          excludelist+=" $(find ./localnet -type d)"
+          excludelist+=" $(find ./proto -type d)"
+          excludelist+=" $(find ./scripts -type d)"
           for filename in ${excludelist}; do
             filename=${filename#".//"}
             echo "Excluding ${filename} from coverage report..."


### PR DESCRIPTION
## Description

If we have a package without test files (`_test.go`), the `go test` will exclude this package from the coverage. We should add the `-coverpkg=./...` to cover all packages. This PR also removes Go files autogenerated by the protobuf and, `app` and `cmd` packages from the coverage.